### PR TITLE
Storage refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,8 +2852,10 @@ name = "rfd-api"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "async-bb8-diesel",
  "async-trait",
  "base64 0.22.1",
+ "bb8",
  "chrono",
  "config",
  "cookie",

--- a/rfd-api/Cargo.toml
+++ b/rfd-api/Cargo.toml
@@ -9,8 +9,10 @@ local-dev = ["v-api/local-dev"]
 
 [dependencies]
 anyhow = { workspace = true }
+async-bb8-diesel = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bb8 = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 config = { workspace = true }
 cookie = { workspace = true }

--- a/rfd-api/src/context.rs
+++ b/rfd-api/src/context.rs
@@ -330,13 +330,13 @@ impl RfdContext {
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
-        sha: Option<String>,
+        commit: Option<CommitSha>,
     ) -> ResourceResult<Rfd, StoreError> {
         let rfd = RfdStore::list(
             &*self.storage,
             vec![RfdFilter::default()
                 .rfd_number(Some(vec![rfd_number]))
-                .sha(sha.map(|sha| vec![sha]))],
+                .commit(commit.map(|commit| vec![commit]))],
             &ListPagination::latest(),
         )
         .await
@@ -362,9 +362,9 @@ impl RfdContext {
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
-        sha: Option<String>,
+        commit: Option<CommitSha>,
     ) -> ResourceResult<RfdWithContent, StoreError> {
-        let rfd = self.get_rfd_by_number(caller, rfd_number, sha).await?;
+        let rfd = self.get_rfd_by_number(caller, rfd_number, commit).await?;
         let pdfs = RfdPdfStore::list(
             &*self.storage,
             vec![RfdPdfFilter::default().rfd_revision(Some(vec![rfd.content.id]))],
@@ -403,7 +403,7 @@ impl RfdContext {
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
-        sha: Option<String>,
+        commit: Option<CommitSha>,
     ) -> ResourceResult<RfdWithoutContent, StoreError> {
         let rfd = self
             .list_rfds(
@@ -411,7 +411,7 @@ impl RfdContext {
                 Some(
                     RfdFilter::default()
                         .rfd_number(Some(vec![rfd_number]))
-                        .sha(sha.map(|sha| vec![sha])),
+                        .commit(commit.map(|commit| vec![commit])),
                 ),
             )
             .await?
@@ -425,9 +425,9 @@ impl RfdContext {
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
-        sha: Option<String>,
+        commit: Option<CommitSha>,
     ) -> ResourceResult<RfdRevision, StoreError> {
-        let rfd = self.get_rfd_by_number(caller, rfd_number, sha).await?;
+        let rfd = self.get_rfd_by_number(caller, rfd_number, commit).await?;
         Ok(rfd.content)
     }
 

--- a/rfd-api/src/context.rs
+++ b/rfd-api/src/context.rs
@@ -18,10 +18,10 @@ use rfd_github::{GitHubError, GitHubNewRfdNumber, GitHubRfdRepo};
 use rfd_model::{
     schema_ext::{ContentFormat, Visibility},
     storage::{
-        JobStore, RfdFilter, RfdPdfFilter, RfdPdfStore, RfdRevisionFilter, RfdRevisionMetaStore,
-        RfdRevisionStore, RfdStore,
+        JobStore, RfdFilter, RfdMetaStore, RfdPdfFilter, RfdPdfStore, RfdRevisionFilter,
+        RfdRevisionMetaStore, RfdStorage, RfdStore,
     },
-    CommitSha, FileSha, Job, NewJob, Rfd, RfdId, RfdRevision,
+    CommitSha, FileSha, Job, NewJob, Rfd, RfdId, RfdMeta, RfdRevision,
 };
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, EncodeRsaPrivateKey},
@@ -51,25 +51,9 @@ use crate::{
 
 static UNLIMITED: i64 = 9999999;
 
-pub trait Storage:
-    RfdStore + RfdRevisionStore + RfdPdfStore + RfdRevisionMetaStore + JobStore + Send + Sync + 'static
-{
-}
-impl<T> Storage for T where
-    T: RfdStore
-        + RfdRevisionStore
-        + RfdPdfStore
-        + RfdRevisionMetaStore
-        + JobStore
-        + Send
-        + Sync
-        + 'static
-{
-}
-
 pub struct RfdContext {
     pub public_url: String,
-    pub storage: Arc<dyn Storage>,
+    pub storage: Arc<dyn RfdStorage>,
     pub search: SearchContext,
     pub content: ContentContext,
     pub github: GitHubRfdRepo,
@@ -107,9 +91,9 @@ pub enum UpdateRfdContentError {
     Storage(#[from] StoreError),
 }
 
-#[partial(RfdMeta)]
+#[partial(RfdWithoutContent)]
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct FullRfd {
+pub struct RfdWithContent {
     pub id: TypedUuid<RfdId>,
     pub rfd_number: i32,
     pub link: Option<String>,
@@ -118,19 +102,19 @@ pub struct FullRfd {
     pub state: Option<String>,
     pub authors: Option<String>,
     pub labels: Option<String>,
-    #[partial(RfdMeta(skip))]
+    #[partial(RfdWithoutContent(skip))]
     pub content: String,
     pub format: ContentFormat,
     pub sha: FileSha,
     pub commit: CommitSha,
     pub committed_at: DateTime<Utc>,
-    #[partial(RfdMeta(skip))]
-    pub pdfs: Vec<FullRfdPdfEntry>,
+    #[partial(RfdWithoutContent(skip))]
+    pub pdfs: Vec<PdfEntry>,
     pub visibility: Visibility,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct FullRfdPdfEntry {
+pub struct PdfEntry {
     pub source: String,
     pub link: String,
 }
@@ -138,7 +122,7 @@ pub struct FullRfdPdfEntry {
 impl RfdContext {
     pub async fn new(
         public_url: String,
-        storage: Arc<dyn Storage>,
+        storage: Arc<dyn RfdStorage>,
         search: SearchConfig,
         content: ContentConfig,
         services: ServicesConfig,
@@ -220,11 +204,11 @@ impl RfdContext {
         &self,
         caller: &Caller<RfdPermission>,
         filter: Option<RfdFilter>,
-    ) -> ResourceResult<Vec<RfdMeta>, StoreError> {
+    ) -> ResourceResult<Vec<RfdWithoutContent>, StoreError> {
         // List all of the RFDs first and then perform filter. This should be be improved once
         // filters can be combined to support OR expressions. Effectively we need to be able to
         // express "Has access to OR is public" with a filter
-        let mut rfds = RfdStore::list(
+        let mut rfds = RfdMetaStore::list(
             &*self.storage,
             filter.unwrap_or_default(),
             &ListPagination::default().limit(UNLIMITED),
@@ -268,7 +252,7 @@ impl RfdContext {
         let mut rfd_list = rfds
             .into_iter()
             .zip(rfd_revisions)
-            .map(|(rfd, revision)| RfdMeta {
+            .map(|(rfd, revision)| RfdWithoutContent {
                 id: rfd.id,
                 rfd_number: rfd.rfd_number,
                 link: rfd.link,
@@ -369,142 +353,144 @@ impl RfdContext {
     }
 
     #[instrument(skip(self, caller))]
-    pub async fn get_rfd(
+    async fn get_rfd_by_number(
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
         sha: Option<String>,
-    ) -> ResourceResult<FullRfd, StoreError> {
-        // list_rfds performs authorization checks, if the caller does not have access to the
-        // requested RFD an empty Vec will be returned
-        let rfds = self
-            .list_rfds(
-                caller,
-                Some(RfdFilter::default().rfd_number(Some(vec![rfd_number]))),
-            )
-            .await?;
+    ) -> ResourceResult<Rfd, StoreError> {
+        let rfd = RfdStore::list(
+            &*self.storage,
+            RfdFilter::default()
+                .rfd_number(Some(vec![rfd_number]))
+                .sha(sha.map(|sha| vec![sha])),
+            &ListPagination::latest(),
+        )
+        .await
+        .to_resource_result()?
+        .pop();
 
-        if let Some(rfd) = rfds.into_iter().nth(0) {
-            // If list_rfds returned a RFD, then the caller is allowed to access that RFD and we
-            // can return the full RFD revision. This is sub-optimal as we are required to execute
-            // the revision lookup twice
-            let latest_revision = RfdRevisionStore::list(
-                &*self.storage,
-                RfdRevisionFilter::default()
-                    .rfd(Some(vec![rfd.id]))
-                    .sha(sha.map(|sha| vec![sha])),
-                &ListPagination::default().limit(1),
-            )
-            .await
-            .to_resource_result()?;
-
-            if let Some(revision) = latest_revision.into_iter().nth(0) {
-                let pdfs = RfdPdfStore::list(
-                    &*self.storage,
-                    RfdPdfFilter::default().rfd_revision(Some(vec![revision.id])),
-                    &ListPagination::default(),
-                )
-                .await
-                .to_resource_result()?;
-
-                Ok(FullRfd {
-                    id: rfd.id,
-                    rfd_number: rfd.rfd_number,
-                    link: rfd.link,
-                    discussion: revision.discussion,
-                    title: revision.title,
-                    state: revision.state,
-                    authors: revision.authors,
-                    labels: revision.labels,
-                    content: revision.content,
-                    format: revision.content_format,
-                    sha: revision.sha,
-                    commit: revision.commit.into(),
-                    committed_at: revision.committed_at,
-                    pdfs: pdfs
-                        .into_iter()
-                        .map(|pdf| FullRfdPdfEntry {
-                            source: pdf.source.to_string(),
-                            link: pdf.link,
-                        })
-                        .collect(),
-                    visibility: rfd.visibility,
-                })
+        if let Some(rfd) = rfd {
+            if caller.can(&RfdPermission::GetRfdsAll)
+                || caller.can(&RfdPermission::GetRfd(rfd.rfd_number))
+                || rfd.visibility == Visibility::Public
+            {
+                Ok(rfd)
             } else {
-                // It should not be possible to reach this branch. If we have then the database
-                // has entered an inconsistent state
-                tracing::error!("Looking up revision for RFD returned no results");
                 resource_not_found()
             }
         } else {
-            // Either the RFD does not exist, or the caller is not allowed to access it
             resource_not_found()
         }
     }
 
     #[instrument(skip(self, caller))]
-    pub async fn get_rfd_meta(
+    pub async fn view_rfd(
+        &self,
+        caller: &Caller<RfdPermission>,
+        rfd_number: i32,
+        sha: Option<String>,
+    ) -> ResourceResult<RfdWithContent, StoreError> {
+        let rfd = self.get_rfd_by_number(caller, rfd_number, sha).await?;
+        let pdfs = RfdPdfStore::list(
+            &*self.storage,
+            RfdPdfFilter::default().rfd_revision(Some(vec![rfd.content.id])),
+            &ListPagination::default(),
+        )
+        .await
+        .to_resource_result()?;
+
+        Ok(RfdWithContent {
+            id: rfd.id,
+            rfd_number: rfd.rfd_number,
+            link: rfd.link,
+            discussion: rfd.content.discussion,
+            title: rfd.content.title,
+            state: rfd.content.state,
+            authors: rfd.content.authors,
+            labels: rfd.content.labels,
+            content: rfd.content.content,
+            format: rfd.content.content_format,
+            sha: rfd.content.sha,
+            commit: rfd.content.commit.into(),
+            committed_at: rfd.content.committed_at,
+            pdfs: pdfs
+                .into_iter()
+                .map(|pdf| PdfEntry {
+                    source: pdf.source.to_string(),
+                    link: pdf.link,
+                })
+                .collect(),
+            visibility: rfd.visibility,
+        })
+    }
+
+    #[instrument(skip(self, caller))]
+    async fn get_rfd_meta_by_number(
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
         sha: Option<String>,
     ) -> ResourceResult<RfdMeta, StoreError> {
-        // list_rfds performs authorization checks, if the caller does not have access to the
-        // requested RFD an empty Vec will be returned
-        let rfds = self
-            .list_rfds(
-                caller,
-                Some(RfdFilter::default().rfd_number(Some(vec![rfd_number]))),
-            )
-            .await?;
+        let rfd = RfdMetaStore::list(
+            &*self.storage,
+            RfdFilter::default()
+                .rfd_number(Some(vec![rfd_number]))
+                .sha(sha.map(|sha| vec![sha])),
+            &ListPagination::latest(),
+        )
+        .await
+        .to_resource_result()?
+        .pop();
 
-        if let Some(rfd) = rfds.into_iter().nth(0) {
-            Ok(rfd)
+        if let Some(rfd) = rfd {
+            if caller.can(&RfdPermission::GetRfdsAll)
+                || caller.can(&RfdPermission::GetRfd(rfd.rfd_number))
+                || rfd.visibility == Visibility::Public
+            {
+                Ok(rfd)
+            } else {
+                resource_not_found()
+            }
         } else {
-            // Either the RFD does not exist, or the caller is not allowed to access it
             resource_not_found()
         }
     }
 
     #[instrument(skip(self, caller))]
-    pub async fn get_rfd_revision(
+    pub async fn view_rfd_meta(
+        &self,
+        caller: &Caller<RfdPermission>,
+        rfd_number: i32,
+        sha: Option<String>,
+    ) -> ResourceResult<RfdWithoutContent, StoreError> {
+        let rfd = self.get_rfd_meta_by_number(caller, rfd_number, sha).await?;
+        Ok(RfdWithoutContent {
+            id: rfd.id,
+            rfd_number: rfd.rfd_number,
+            link: rfd.link,
+            discussion: rfd.content.discussion,
+            title: rfd.content.title,
+            state: rfd.content.state,
+            authors: rfd.content.authors,
+            labels: rfd.content.labels,
+            format: rfd.content.content_format,
+            sha: rfd.content.sha,
+            commit: rfd.content.commit.into(),
+            committed_at: rfd.content.committed_at,
+            visibility: rfd.visibility,
+        })
+    }
+
+    #[instrument(skip(self, caller))]
+    pub async fn view_rfd_revision(
         &self,
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
         sha: Option<String>,
     ) -> ResourceResult<RfdRevision, StoreError> {
-        if caller.any(&[
-            &RfdPermission::GetRfd(rfd_number),
-            &RfdPermission::GetRfdsAll,
-        ]) {
-            let rfds = RfdStore::list(
-                &*self.storage,
-                RfdFilter::default().rfd_number(Some(vec![rfd_number])),
-                &ListPagination::default().limit(1),
-            )
-            .await
-            .to_resource_result()?;
-            if let Some(rfd) = rfds.into_iter().nth(0) {
-                let latest_revision = RfdRevisionStore::list(
-                    &*self.storage,
-                    RfdRevisionFilter::default()
-                        .rfd(Some(vec![rfd.id]))
-                        .sha(sha.map(|sha| vec![sha])),
-                    &ListPagination::default().limit(1),
-                )
-                .await
-                .to_resource_result()?;
-
-                match latest_revision.into_iter().nth(0) {
-                    Some(revision) => Ok(revision),
-                    None => resource_not_found(),
-                }
-            } else {
-                resource_not_found()
-            }
-        } else {
-            resource_restricted()
-        }
+        let rfd = self.get_rfd_by_number(caller, rfd_number, sha).await?;
+        Ok(rfd.content)
     }
 
     async fn get_latest_rfd_revision(
@@ -512,37 +498,7 @@ impl RfdContext {
         caller: &Caller<RfdPermission>,
         rfd_number: i32,
     ) -> ResourceResult<RfdRevision, StoreError> {
-        if caller.any(&[
-            &RfdPermission::GetRfd(rfd_number),
-            &RfdPermission::GetRfdsAll,
-        ]) {
-            let rfds = RfdStore::list(
-                &*self.storage,
-                RfdFilter::default().rfd_number(Some(vec![rfd_number])),
-                &ListPagination::default().limit(1),
-            )
-            .await
-            .to_resource_result()?;
-
-            if let Some(rfd) = rfds.into_iter().nth(0) {
-                let revisions = RfdRevisionStore::list(
-                    &*self.storage,
-                    RfdRevisionFilter::default().rfd(Some(vec![rfd.id])),
-                    &ListPagination::default().limit(1),
-                )
-                .await
-                .to_resource_result()?;
-
-                match revisions.into_iter().nth(0) {
-                    Some(revision) => Ok(revision),
-                    None => resource_not_found(),
-                }
-            } else {
-                resource_not_found()
-            }
-        } else {
-            resource_restricted()
-        }
+        self.view_rfd_revision(caller, rfd_number, None).await
     }
 
     #[instrument(skip(self, caller, content))]
@@ -767,18 +723,9 @@ impl RfdContext {
 
 #[cfg(test)]
 pub(crate) mod test_mocks {
-    use async_trait::async_trait;
-    use newtype_uuid::TypedUuid;
     use rand::RngCore;
     use rfd_data::content::RfdTemplate;
-    use rfd_model::{
-        storage::{
-            JobStore, MockJobStore, MockRfdPdfStore, MockRfdRevisionMetaStore,
-            MockRfdRevisionStore, MockRfdStore, RfdPdfStore, RfdRevisionMetaStore,
-            RfdRevisionStore, RfdStore,
-        },
-        NewJob, NewRfd, NewRfdPdf, NewRfdRevision, RfdId, RfdPdfId, RfdRevisionId,
-    };
+    use rfd_model::storage::mock::MockStorage;
     use rsa::{
         pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding},
         RsaPrivateKey, RsaPublicKey,
@@ -789,7 +736,7 @@ pub(crate) mod test_mocks {
         endpoints::login::oauth::{google::GoogleOAuthProvider, OAuthProviderName},
         VContext,
     };
-    use v_model::storage::{postgres::PostgresStore, ListPagination, StoreError};
+    use v_model::storage::postgres::PostgresStore;
 
     use crate::config::{
         ContentConfig, GitHubAuthConfig, GitHubConfig, SearchConfig, ServicesConfig,
@@ -873,221 +820,5 @@ pub(crate) mod test_mocks {
         .unwrap();
 
         ctx
-    }
-
-    // Construct a mock storage engine that can be wrapped in an ApiContext for testing
-    pub struct MockStorage {
-        pub rfd_store: Option<Arc<MockRfdStore>>,
-        pub rfd_revision_store: Option<Arc<MockRfdRevisionStore>>,
-        pub rfd_pdf_store: Option<Arc<MockRfdPdfStore>>,
-        pub rfd_revision_meta_store: Option<Arc<MockRfdRevisionMetaStore>>,
-        pub job_store: Option<Arc<MockJobStore>>,
-    }
-
-    impl MockStorage {
-        pub fn new() -> Self {
-            Self {
-                rfd_store: None,
-                rfd_revision_store: None,
-                rfd_pdf_store: None,
-                rfd_revision_meta_store: None,
-                job_store: None,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl RfdStore for MockStorage {
-        async fn get(
-            &self,
-            id: &TypedUuid<RfdId>,
-            deleted: bool,
-        ) -> Result<Option<rfd_model::Rfd>, StoreError> {
-            self.rfd_store.as_ref().unwrap().get(id, deleted).await
-        }
-
-        async fn list(
-            &self,
-            filter: rfd_model::storage::RfdFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::Rfd>, StoreError> {
-            self.rfd_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-
-        async fn upsert(&self, new_rfd: NewRfd) -> Result<rfd_model::Rfd, StoreError> {
-            self.rfd_store.as_ref().unwrap().upsert(new_rfd).await
-        }
-
-        async fn delete(
-            &self,
-            id: &TypedUuid<RfdId>,
-        ) -> Result<Option<rfd_model::Rfd>, StoreError> {
-            self.rfd_store.as_ref().unwrap().delete(id).await
-        }
-    }
-
-    #[async_trait]
-    impl RfdRevisionStore for MockStorage {
-        async fn get(
-            &self,
-            id: &TypedUuid<RfdRevisionId>,
-            deleted: bool,
-        ) -> Result<Option<rfd_model::RfdRevision>, StoreError> {
-            self.rfd_revision_store
-                .as_ref()
-                .unwrap()
-                .get(id, deleted)
-                .await
-        }
-
-        async fn list(
-            &self,
-            filter: rfd_model::storage::RfdRevisionFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::RfdRevision>, StoreError> {
-            self.rfd_revision_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-
-        async fn list_unique_rfd(
-            &self,
-            filter: rfd_model::storage::RfdRevisionFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::RfdRevision>, StoreError> {
-            self.rfd_revision_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-
-        async fn upsert(
-            &self,
-            new_revision: NewRfdRevision,
-        ) -> Result<rfd_model::RfdRevision, StoreError> {
-            self.rfd_revision_store
-                .as_ref()
-                .unwrap()
-                .upsert(new_revision)
-                .await
-        }
-
-        async fn delete(
-            &self,
-            id: &TypedUuid<RfdRevisionId>,
-        ) -> Result<Option<rfd_model::RfdRevision>, StoreError> {
-            self.rfd_revision_store.as_ref().unwrap().delete(id).await
-        }
-    }
-
-    #[async_trait]
-    impl RfdRevisionMetaStore for MockStorage {
-        async fn get(
-            &self,
-            id: &TypedUuid<RfdRevisionId>,
-            deleted: bool,
-        ) -> Result<Option<rfd_model::RfdRevisionMeta>, StoreError> {
-            self.rfd_revision_meta_store
-                .as_ref()
-                .unwrap()
-                .get(id, deleted)
-                .await
-        }
-
-        async fn list(
-            &self,
-            filter: rfd_model::storage::RfdRevisionFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::RfdRevisionMeta>, StoreError> {
-            self.rfd_revision_meta_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-
-        async fn list_unique_rfd(
-            &self,
-            filter: rfd_model::storage::RfdRevisionFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::RfdRevisionMeta>, StoreError> {
-            self.rfd_revision_meta_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-    }
-
-    #[async_trait]
-    impl RfdPdfStore for MockStorage {
-        async fn get(
-            &self,
-            id: &TypedUuid<RfdPdfId>,
-            deleted: bool,
-        ) -> Result<Option<rfd_model::RfdPdf>, StoreError> {
-            self.rfd_pdf_store.as_ref().unwrap().get(id, deleted).await
-        }
-
-        async fn list(
-            &self,
-            filter: rfd_model::storage::RfdPdfFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::RfdPdf>, StoreError> {
-            self.rfd_pdf_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-
-        async fn upsert(&self, new_pdf: NewRfdPdf) -> Result<rfd_model::RfdPdf, StoreError> {
-            self.rfd_pdf_store.as_ref().unwrap().upsert(new_pdf).await
-        }
-
-        async fn delete(
-            &self,
-            id: &TypedUuid<RfdPdfId>,
-        ) -> Result<Option<rfd_model::RfdPdf>, StoreError> {
-            self.rfd_pdf_store.as_ref().unwrap().delete(id).await
-        }
-    }
-
-    #[async_trait]
-    impl JobStore for MockStorage {
-        async fn get(&self, id: i32) -> Result<Option<rfd_model::Job>, StoreError> {
-            self.job_store.as_ref().unwrap().get(id).await
-        }
-
-        async fn list(
-            &self,
-            filter: rfd_model::storage::JobFilter,
-            pagination: &ListPagination,
-        ) -> Result<Vec<rfd_model::Job>, StoreError> {
-            self.job_store
-                .as_ref()
-                .unwrap()
-                .list(filter, pagination)
-                .await
-        }
-
-        async fn upsert(&self, new_job: NewJob) -> Result<rfd_model::Job, StoreError> {
-            self.job_store.as_ref().unwrap().upsert(new_job).await
-        }
-
-        async fn start(&self, id: i32) -> Result<Option<rfd_model::Job>, StoreError> {
-            self.job_store.as_ref().unwrap().start(id).await
-        }
-
-        async fn complete(&self, id: i32) -> Result<Option<rfd_model::Job>, StoreError> {
-            self.job_store.as_ref().unwrap().complete(id).await
-        }
     }
 }

--- a/rfd-api/src/endpoints/meta.rs
+++ b/rfd-api/src/endpoints/meta.rs
@@ -65,9 +65,7 @@ mod tests {
     use http::StatusCode;
     use newtype_uuid::{GenericUuid, TypedUuid};
     use rfd_model::{
-        schema_ext::ContentFormat,
-        storage::{mock::MockStorage, MockRfdRevisionMetaStore, MockRfdStore},
-        CommitSha, FileSha, Rfd, RfdRevision, RfdRevisionMeta,
+        schema_ext::ContentFormat, storage::{mock::MockStorage, MockRfdMetaStore, MockRfdRevisionMetaStore, MockRfdStore}, CommitSha, FileSha, Rfd, RfdMeta, RfdRevision, RfdRevisionMeta
     };
     use uuid::Uuid;
     use v_api::ApiContext;
@@ -152,6 +150,98 @@ mod tests {
                         authors: None,
                         labels: None,
                         content: String::new(),
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    deleted_at: None,
+                    visibility: rfd_model::schema_ext::Visibility::Private,
+                },
+            ];
+
+            results.retain(|rfd| {
+                filter.rfd_number.is_none()
+                    || filter
+                        .rfd_number
+                        .as_ref()
+                        .unwrap()
+                        .contains(&rfd.rfd_number)
+            });
+
+            Ok(results)
+        });
+
+        let mut rfd_meta_store = MockRfdMetaStore::new();
+        rfd_meta_store.expect_list().returning(move |filter, _| {
+            let mut results = vec![
+                RfdMeta {
+                    id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                    rfd_number: 123,
+                    link: None,
+                    content: RfdRevisionMeta {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    deleted_at: None,
+                    visibility: rfd_model::schema_ext::Visibility::Private,
+                },
+                RfdMeta {
+                    id: TypedUuid::from_untyped_uuid(public_rfd_id),
+                    rfd_number: 456,
+                    link: None,
+                    content: RfdRevisionMeta {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    deleted_at: None,
+                    visibility: rfd_model::schema_ext::Visibility::Public,
+                },
+                RfdMeta {
+                    id: TypedUuid::from_untyped_uuid(private_rfd_id_2),
+                    rfd_number: 789,
+                    link: None,
+                    content: RfdRevisionMeta {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
                         content_format: ContentFormat::Asciidoc,
                         sha: FileSha(String::new()),
                         commit: CommitSha(String::new()),

--- a/rfd-api/src/endpoints/meta.rs
+++ b/rfd-api/src/endpoints/meta.rs
@@ -168,8 +168,9 @@ mod tests {
             ];
 
             results.retain(|rfd| {
-                filter.rfd_number.is_none()
-                    || filter
+                filter.len() == 0
+                    || filter[0].rfd_number.is_none()
+                    || filter[0]
                         .rfd_number
                         .as_ref()
                         .unwrap()
@@ -260,8 +261,9 @@ mod tests {
             ];
 
             results.retain(|rfd| {
-                filter.rfd_number.is_none()
-                    || filter
+                filter.len() == 0
+                    || filter[0].rfd_number.is_none()
+                    || filter[0]
                         .rfd_number
                         .as_ref()
                         .unwrap()
@@ -327,7 +329,9 @@ mod tests {
                 ];
 
                 results.retain(|revision| {
-                    filter.rfd.is_none() || filter.rfd.as_ref().unwrap().contains(&revision.rfd_id)
+                    filter.len() == 0
+                        || filter[0].rfd.is_none()
+                        || filter[0].rfd.as_ref().unwrap().contains(&revision.rfd_id)
                 });
 
                 Ok(results)

--- a/rfd-api/src/endpoints/meta.rs
+++ b/rfd-api/src/endpoints/meta.rs
@@ -65,7 +65,9 @@ mod tests {
     use http::StatusCode;
     use newtype_uuid::{GenericUuid, TypedUuid};
     use rfd_model::{
-        schema_ext::ContentFormat, storage::{mock::MockStorage, MockRfdMetaStore, MockRfdRevisionMetaStore, MockRfdStore}, CommitSha, FileSha, Rfd, RfdMeta, RfdRevision, RfdRevisionMeta
+        schema_ext::ContentFormat,
+        storage::{mock::MockStorage, MockRfdMetaStore, MockRfdRevisionMetaStore, MockRfdStore},
+        CommitSha, FileSha, Rfd, RfdMeta, RfdRevision, RfdRevisionMeta,
     };
     use uuid::Uuid;
     use v_api::ApiContext;
@@ -333,6 +335,7 @@ mod tests {
 
         let mut storage = MockStorage::new();
         storage.rfd_store = Some(Arc::new(rfd_store));
+        storage.rfd_meta_store = Some(Arc::new(rfd_meta_store));
         storage.rfd_revision_meta_store = Some(Arc::new(rfd_revision_meta_store));
 
         mock_context(storage).await

--- a/rfd-api/src/endpoints/rfd.rs
+++ b/rfd-api/src/endpoints/rfd.rs
@@ -23,7 +23,7 @@ use v_model::permissions::Caller;
 
 use crate::{
     caller::CallerExt,
-    context::{FullRfd, RfdContext, RfdMeta},
+    context::{RfdContext, RfdWithContent, RfdWithoutContent},
     permissions::RfdPermission,
     search::{MeiliSearchResult, SearchRequest},
     util::response::{client_error, internal_error, unauthorized},
@@ -36,19 +36,19 @@ use crate::{
     path = "/rfd",
 }]
 #[instrument(skip(rqctx), fields(request_id = rqctx.request_id), err(Debug))]
-pub async fn get_rfds(
+pub async fn list_rfds(
     rqctx: RequestContext<RfdContext>,
-) -> Result<HttpResponseOk<Vec<RfdMeta>>, HttpError> {
+) -> Result<HttpResponseOk<Vec<RfdWithoutContent>>, HttpError> {
     let ctx = rqctx.context();
     let caller = ctx.v_ctx().get_caller(&rqctx).await?;
-    get_rfds_op(ctx, &caller).await
+    list_rfds_op(ctx, &caller).await
 }
 
 #[instrument(skip(ctx, caller), fields(caller = ?caller.id), err(Debug))]
-async fn get_rfds_op(
+async fn list_rfds_op(
     ctx: &RfdContext,
     caller: &Caller<RfdPermission>,
-) -> Result<HttpResponseOk<Vec<RfdMeta>>, HttpError> {
+) -> Result<HttpResponseOk<Vec<RfdWithoutContent>>, HttpError> {
     let rfds = ctx.list_rfds(caller, None).await?;
     Ok(HttpResponseOk(rfds))
 }
@@ -107,23 +107,25 @@ pub struct RfdPathParams {
     path = "/rfd/{number}",
 }]
 #[instrument(skip(rqctx), fields(request_id = rqctx.request_id), err(Debug))]
-pub async fn get_rfd(
+pub async fn view_rfd(
     rqctx: RequestContext<RfdContext>,
     path: Path<RfdPathParams>,
-) -> Result<HttpResponseOk<FullRfd>, HttpError> {
+) -> Result<HttpResponseOk<RfdWithContent>, HttpError> {
     let ctx = rqctx.context();
     let caller = ctx.v_ctx().get_caller(&rqctx).await?;
-    get_rfd_op(ctx, &caller, path.into_inner().number).await
+    view_rfd_op(ctx, &caller, path.into_inner().number).await
 }
 
 #[instrument(skip(ctx, caller), fields(caller = ?caller.id), err(Debug))]
-async fn get_rfd_op(
+async fn view_rfd_op(
     ctx: &RfdContext,
     caller: &Caller<RfdPermission>,
     number: String,
-) -> Result<HttpResponseOk<FullRfd>, HttpError> {
+) -> Result<HttpResponseOk<RfdWithContent>, HttpError> {
     if let Ok(rfd_number) = number.parse::<i32>() {
-        Ok(HttpResponseOk(ctx.get_rfd(caller, rfd_number, None).await?))
+        Ok(HttpResponseOk(
+            ctx.view_rfd(caller, rfd_number, None).await?,
+        ))
     } else {
         Err(client_error(
             ClientErrorStatusCode::BAD_REQUEST,
@@ -257,25 +259,25 @@ pub enum RfdAttr {
     path = "/rfd/{number}/attr/{attr}",
 }]
 #[instrument(skip(rqctx), fields(request_id = rqctx.request_id), err(Debug))]
-pub async fn get_rfd_attr(
+pub async fn view_rfd_attr(
     rqctx: RequestContext<RfdContext>,
     path: Path<RfdAttrPathParams>,
 ) -> Result<HttpResponseOk<RfdAttr>, HttpError> {
     let ctx = rqctx.context();
     let caller = ctx.v_ctx().get_caller(&rqctx).await?;
     let path = path.into_inner();
-    get_rfd_attr_op(ctx, &caller, path.number, path.attr).await
+    view_rfd_attr_op(ctx, &caller, path.number, path.attr).await
 }
 
 #[instrument(skip(ctx, caller), fields(caller = ?caller.id), err(Debug))]
-async fn get_rfd_attr_op(
+async fn view_rfd_attr_op(
     ctx: &RfdContext,
     caller: &Caller<RfdPermission>,
     number: String,
     attr: RfdAttrName,
 ) -> Result<HttpResponseOk<RfdAttr>, HttpError> {
     if let Ok(rfd_number) = number.parse::<i32>() {
-        let rfd = ctx.get_rfd(caller, rfd_number, None).await?;
+        let rfd = ctx.view_rfd(caller, rfd_number, None).await?;
         let content = match rfd.format {
             ContentFormat::Asciidoc => RfdContent::Asciidoc(RfdAsciidoc::new(rfd.content)),
             ContentFormat::Markdown => RfdContent::Markdown(RfdMarkdown::new(rfd.content)),
@@ -326,7 +328,7 @@ async fn set_rfd_attr_op(
 ) -> Result<HttpResponseAccepted<RfdAttr>, HttpError> {
     if let Ok(rfd_number) = number.parse::<i32>() {
         // Get the latest revision
-        let revision = ctx.get_rfd_revision(caller, rfd_number, None).await?;
+        let revision = ctx.view_rfd_revision(caller, rfd_number, None).await?;
 
         // TODO: Get rid of these clones
         let mut content = match revision.content_format {
@@ -648,23 +650,24 @@ mod tests {
     use http::StatusCode;
     use newtype_uuid::{GenericUuid, TypedUuid};
     use rfd_model::{
-        storage::{MockRfdPdfStore, MockRfdRevisionMetaStore, MockRfdRevisionStore, MockRfdStore},
-        Rfd, RfdRevision, RfdRevisionMeta,
+        schema_ext::ContentFormat,
+        storage::{
+            mock::MockStorage, MockRfdPdfStore, MockRfdRevisionMetaStore, MockRfdRevisionStore,
+            MockRfdStore,
+        },
+        CommitSha, FileSha, Rfd, RfdRevision, RfdRevisionMeta,
     };
     use uuid::Uuid;
     use v_api::ApiContext;
     use v_model::{permissions::Caller, Permissions};
 
     use crate::{
-        context::{
-            test_mocks::{mock_context, MockStorage},
-            RfdContext,
-        },
-        endpoints::rfd::get_rfd_op,
+        context::{test_mocks::mock_context, RfdContext},
+        endpoints::rfd::view_rfd_op,
         permissions::RfdPermission,
     };
 
-    use super::get_rfds_op;
+    use super::list_rfds_op;
 
     async fn ctx() -> RfdContext {
         let private_rfd_id_1 = Uuid::new_v4();
@@ -678,6 +681,23 @@ mod tests {
                     id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
                     rfd_number: 123,
                     link: None,
+                    content: RfdRevision {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content: String::new(),
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                     deleted_at: None,
@@ -687,6 +707,23 @@ mod tests {
                     id: TypedUuid::from_untyped_uuid(public_rfd_id),
                     rfd_number: 456,
                     link: None,
+                    content: RfdRevision {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content: String::new(),
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                     deleted_at: None,
@@ -696,6 +733,23 @@ mod tests {
                     id: TypedUuid::from_untyped_uuid(private_rfd_id_2),
                     rfd_number: 789,
                     link: None,
+                    content: RfdRevision {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content: String::new(),
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                     deleted_at: None,
@@ -866,7 +920,7 @@ mod tests {
         let ctx = ctx().await;
         let caller = Caller::from(Permissions::from(vec![RfdPermission::GetRfdsAll]));
 
-        let HttpResponseOk(rfds) = get_rfds_op(&ctx, &caller).await.unwrap();
+        let HttpResponseOk(rfds) = list_rfds_op(&ctx, &caller).await.unwrap();
         assert_eq!(3, rfds.len());
         assert_eq!(789, rfds[0].rfd_number);
         assert_eq!(456, rfds[1].rfd_number);
@@ -874,14 +928,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_rfd_via_all_permission() {
+    async fn view_rfd_via_all_permission() {
         let ctx = ctx().await;
         let caller = Caller::from(Permissions::from(vec![RfdPermission::GetRfdsAll]));
 
-        let HttpResponseOk(rfd) = get_rfd_op(&ctx, &caller, "0123".to_string()).await.unwrap();
+        let HttpResponseOk(rfd) = view_rfd_op(&ctx, &caller, "0123".to_string())
+            .await
+            .unwrap();
         assert_eq!(123, rfd.rfd_number);
 
-        let HttpResponseOk(rfd) = get_rfd_op(&ctx, &caller, "0456".to_string()).await.unwrap();
+        let HttpResponseOk(rfd) = view_rfd_op(&ctx, &caller, "0456".to_string())
+            .await
+            .unwrap();
         assert_eq!(456, rfd.rfd_number);
     }
 
@@ -892,21 +950,25 @@ mod tests {
         let ctx = ctx().await;
         let caller = Caller::from(Permissions::from(vec![RfdPermission::GetRfd(123)]));
 
-        let HttpResponseOk(rfds) = get_rfds_op(&ctx, &caller).await.unwrap();
+        let HttpResponseOk(rfds) = list_rfds_op(&ctx, &caller).await.unwrap();
         assert_eq!(2, rfds.len());
         assert_eq!(456, rfds[0].rfd_number);
         assert_eq!(123, rfds[1].rfd_number);
     }
 
     #[tokio::test]
-    async fn get_rfd_with_direct_permission() {
+    async fn view_rfd_with_direct_permission() {
         let ctx = ctx().await;
         let caller = Caller::from(Permissions::from(vec![RfdPermission::GetRfd(123)]));
 
-        let HttpResponseOk(rfd) = get_rfd_op(&ctx, &caller, "0123".to_string()).await.unwrap();
+        let HttpResponseOk(rfd) = view_rfd_op(&ctx, &caller, "0123".to_string())
+            .await
+            .unwrap();
         assert_eq!(123, rfd.rfd_number);
 
-        let HttpResponseOk(rfd) = get_rfd_op(&ctx, &caller, "0456".to_string()).await.unwrap();
+        let HttpResponseOk(rfd) = view_rfd_op(&ctx, &caller, "0456".to_string())
+            .await
+            .unwrap();
         assert_eq!(456, rfd.rfd_number);
     }
 
@@ -917,17 +979,17 @@ mod tests {
         let ctx = ctx().await;
         let caller = Caller::from(Permissions::<RfdPermission>::new());
 
-        let HttpResponseOk(rfds) = get_rfds_op(&ctx, &caller).await.unwrap();
+        let HttpResponseOk(rfds) = list_rfds_op(&ctx, &caller).await.unwrap();
         assert_eq!(1, rfds.len());
         assert_eq!(456, rfds[0].rfd_number);
     }
 
     #[tokio::test]
-    async fn get_rfd_without_permission() {
+    async fn view_rfd_without_permission() {
         let ctx = ctx().await;
         let caller = Caller::from(Permissions::<RfdPermission>::new());
 
-        let result = get_rfd_op(&ctx, &caller, "0123".to_string()).await;
+        let result = view_rfd_op(&ctx, &caller, "0123".to_string()).await;
 
         match result {
             Err(err) => assert_eq!(StatusCode::NOT_FOUND, err.status_code),
@@ -944,19 +1006,20 @@ mod tests {
     async fn list_rfds_as_unauthenticated() {
         let ctx = ctx().await;
 
-        let HttpResponseOk(rfds) = get_rfds_op(&ctx, &ctx.v_ctx().builtin_unauthenticated_caller())
-            .await
-            .unwrap();
+        let HttpResponseOk(rfds) =
+            list_rfds_op(&ctx, &ctx.v_ctx().builtin_unauthenticated_caller())
+                .await
+                .unwrap();
         assert_eq!(1, rfds.len());
         assert_eq!(456, rfds[0].rfd_number);
     }
 
     #[tokio::test]
-    async fn get_rfd_as_unauthenticated() {
+    async fn view_rfd_as_unauthenticated() {
         let ctx = ctx().await;
         let caller = ctx.v_ctx().builtin_unauthenticated_caller();
 
-        let result = get_rfd_op(&ctx, &caller, "0123".to_string()).await;
+        let result = view_rfd_op(&ctx, &caller, "0123".to_string()).await;
         match result {
             Err(err) => assert_eq!(StatusCode::NOT_FOUND, err.status_code),
             Ok(response) => panic!(

--- a/rfd-api/src/endpoints/rfd.rs
+++ b/rfd-api/src/endpoints/rfd.rs
@@ -652,10 +652,10 @@ mod tests {
     use rfd_model::{
         schema_ext::ContentFormat,
         storage::{
-            mock::MockStorage, MockRfdPdfStore, MockRfdRevisionMetaStore, MockRfdRevisionStore,
-            MockRfdStore,
+            mock::MockStorage, MockRfdMetaStore, MockRfdPdfStore, MockRfdRevisionMetaStore,
+            MockRfdRevisionStore, MockRfdStore,
         },
-        CommitSha, FileSha, Rfd, RfdRevision, RfdRevisionMeta,
+        CommitSha, FileSha, Rfd, RfdMeta, RfdRevision, RfdRevisionMeta,
     };
     use uuid::Uuid;
     use v_api::ApiContext;
@@ -742,6 +742,98 @@ mod tests {
                         authors: None,
                         labels: None,
                         content: String::new(),
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    deleted_at: None,
+                    visibility: rfd_model::schema_ext::Visibility::Private,
+                },
+            ];
+
+            results.retain(|rfd| {
+                filter.rfd_number.is_none()
+                    || filter
+                        .rfd_number
+                        .as_ref()
+                        .unwrap()
+                        .contains(&rfd.rfd_number)
+            });
+
+            Ok(results)
+        });
+
+        let mut rfd_meta_store = MockRfdMetaStore::new();
+        rfd_meta_store.expect_list().returning(move |filter, _| {
+            let mut results = vec![
+                RfdMeta {
+                    id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                    rfd_number: 123,
+                    link: None,
+                    content: RfdRevisionMeta {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    deleted_at: None,
+                    visibility: rfd_model::schema_ext::Visibility::Private,
+                },
+                RfdMeta {
+                    id: TypedUuid::from_untyped_uuid(public_rfd_id),
+                    rfd_number: 456,
+                    link: None,
+                    content: RfdRevisionMeta {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
+                        content_format: ContentFormat::Asciidoc,
+                        sha: FileSha(String::new()),
+                        commit: CommitSha(String::new()),
+                        committed_at: Utc::now(),
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        deleted_at: None,
+                    },
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    deleted_at: None,
+                    visibility: rfd_model::schema_ext::Visibility::Public,
+                },
+                RfdMeta {
+                    id: TypedUuid::from_untyped_uuid(private_rfd_id_2),
+                    rfd_number: 789,
+                    link: None,
+                    content: RfdRevisionMeta {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: TypedUuid::from_untyped_uuid(private_rfd_id_1),
+                        title: String::new(),
+                        state: None,
+                        discussion: None,
+                        authors: None,
+                        labels: None,
                         content_format: ContentFormat::Asciidoc,
                         sha: FileSha(String::new()),
                         commit: CommitSha(String::new()),
@@ -906,6 +998,7 @@ mod tests {
 
         let mut storage = MockStorage::new();
         storage.rfd_store = Some(Arc::new(rfd_store));
+        storage.rfd_meta_store = Some(Arc::new(rfd_meta_store));
         storage.rfd_revision_store = Some(Arc::new(rfd_revision_store));
         storage.rfd_revision_meta_store = Some(Arc::new(rfd_revision_meta_store));
         storage.rfd_pdf_store = Some(Arc::new(rfd_pdf_store));

--- a/rfd-api/src/endpoints/rfd.rs
+++ b/rfd-api/src/endpoints/rfd.rs
@@ -758,8 +758,9 @@ mod tests {
             ];
 
             results.retain(|rfd| {
-                filter.rfd_number.is_none()
-                    || filter
+                filter.len() == 0
+                    || filter[0].rfd_number.is_none()
+                    || filter[0]
                         .rfd_number
                         .as_ref()
                         .unwrap()
@@ -850,8 +851,9 @@ mod tests {
             ];
 
             results.retain(|rfd| {
-                filter.rfd_number.is_none()
-                    || filter
+                filter.len() == 0
+                    || filter[0].rfd_number.is_none()
+                    || filter[0]
                         .rfd_number
                         .as_ref()
                         .unwrap()
@@ -923,7 +925,8 @@ mod tests {
                 ];
 
                 results.retain(|revision| {
-                    filter.rfd.is_none() || filter.rfd.as_ref().unwrap().contains(&revision.rfd_id)
+                    filter[0].rfd.is_none()
+                        || filter[0].rfd.as_ref().unwrap().contains(&revision.rfd_id)
                 });
 
                 Ok(results)
@@ -985,7 +988,9 @@ mod tests {
                 ];
 
                 results.retain(|revision| {
-                    filter.rfd.is_none() || filter.rfd.as_ref().unwrap().contains(&revision.rfd_id)
+                    filter.len() == 0
+                        || filter[0].rfd.is_none()
+                        || filter[0].rfd.as_ref().unwrap().contains(&revision.rfd_id)
                 });
 
                 Ok(results)

--- a/rfd-api/src/main.rs
+++ b/rfd-api/src/main.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use context::RfdContext;
-use rfd_model::storage::postgres::PostgresStore;
 use server::{server, ServerConfig};
 use std::{
     net::{SocketAddr, SocketAddrV4},
@@ -18,7 +17,7 @@ use v_api::{
     },
     ApiContext, VContext,
 };
-use v_model::storage::postgres::PostgresStore as VApiPostgressStore;
+use v_model::storage::postgres::PostgresStore as VApiPostgresStore;
 
 use crate::{
     config::{AppConfig, ServerLogFormat},
@@ -69,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
     let mut v_ctx = VContext::new(
         config.public_url.clone(),
         Arc::new(
-            VApiPostgressStore::new(&config.database_url)
+            VApiPostgresStore::new(&config.database_url)
                 .await
                 .tap_err(|err| {
                     tracing::error!(?err, "Failed to establish initial database connection");
@@ -120,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
     let context = RfdContext::new(
         config.public_url,
         Arc::new(
-            PostgresStore::new(&config.database_url)
+            VApiPostgresStore::new(&config.database_url)
                 .await
                 .tap_err(|err| {
                     tracing::error!(?err, "Failed to establish initial database connection");

--- a/rfd-api/src/server.rs
+++ b/rfd-api/src/server.rs
@@ -15,10 +15,10 @@ use v_api::{inject_endpoints, v_system_endpoints};
 use crate::{
     context::RfdContext,
     endpoints::{
-        meta::get_rfd_meta,
+        meta::view_rfd_meta,
         rfd::{
-            discuss_rfd, get_rfd, get_rfd_attr, get_rfds, publish_rfd, reserve_rfd, search_rfds,
-            set_rfd_attr, set_rfd_content, set_rfd_document, update_rfd_visibility,
+            discuss_rfd, list_rfds, publish_rfd, reserve_rfd, search_rfds, set_rfd_attr,
+            set_rfd_content, set_rfd_document, update_rfd_visibility, view_rfd, view_rfd_attr,
         },
         webhook::github_webhook,
     },
@@ -74,9 +74,10 @@ pub fn server(
     inject_endpoints!(api);
 
     // RFDs
-    api.register(get_rfds).expect("Failed to register endpoint");
-    api.register(get_rfd).expect("Failed to register endpoint");
-    api.register(get_rfd_meta)
+    api.register(list_rfds)
+        .expect("Failed to register endpoint");
+    api.register(view_rfd).expect("Failed to register endpoint");
+    api.register(view_rfd_meta)
         .expect("Failed to register endpoint");
     api.register(reserve_rfd)
         .expect("Failed to register endpoint");
@@ -84,7 +85,7 @@ pub fn server(
         .expect("Failed to register endpoint");
     api.register(set_rfd_content)
         .expect("Failed to register endpoint");
-    api.register(get_rfd_attr)
+    api.register(view_rfd_attr)
         .expect("Failed to register endpoint");
     api.register(set_rfd_attr)
         .expect("Failed to register endpoint");

--- a/rfd-cli/src/main.rs
+++ b/rfd-cli/src/main.rs
@@ -409,7 +409,7 @@ impl ProgenitorCliConfig for Context {
                 .printer()
                 .unwrap()
                 .output_oauth_secret(reserialize(value)),
-            "Array_of_ListRfd" => self.printer().unwrap().output_rfd_list(reserialize(value)),
+            "Array_of_RfdMeta" => self.printer().unwrap().output_rfd_list(reserialize(value)),
             "FullRfd" => self.printer().unwrap().output_rfd_full(reserialize(value)),
             "Rfd" => self.printer().unwrap().output_rfd(reserialize(value)),
             "SearchResults" => self

--- a/rfd-github/src/lib.rs
+++ b/rfd-github/src/lib.rs
@@ -730,6 +730,28 @@ impl GitHubRfdLocation {
     }
 }
 
+#[derive(Clone)]
+struct GitHubPullRequestComments {
+    pub client: Client,
+}
+
+impl GitHubPullRequestComments {
+    async fn comments(&self) {
+        let pulls = self.client.pulls();
+        let comments = pulls
+            .list_all_review_comments(
+                "owner",
+                "repo",
+                0,
+                octorust::types::Sort::Created,
+                octorust::types::Order::Desc,
+                None,
+            )
+            .await
+            .unwrap();
+    }
+}
+
 struct FetchedRfdContent {
     decoded: Vec<u8>,
     parsed: String,

--- a/rfd-model/src/db.rs
+++ b/rfd-model/src/db.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use chrono::{DateTime, Utc};
-use diesel::{Insertable, Queryable};
+use diesel::{Insertable, Queryable, Selectable};
 use partial_struct::partial;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -13,7 +13,7 @@ use crate::{
     schema_ext::{ContentFormat, PdfSource, Visibility},
 };
 
-#[derive(Debug, Deserialize, Serialize, Queryable, Insertable)]
+#[derive(Debug, Deserialize, Serialize, Queryable, Insertable, Selectable)]
 #[diesel(table_name = rfd)]
 pub struct RfdModel {
     pub id: Uuid,
@@ -26,7 +26,7 @@ pub struct RfdModel {
 }
 
 #[partial(RfdRevisionMetaModel)]
-#[derive(Debug, Deserialize, Serialize, Queryable, Insertable)]
+#[derive(Debug, Deserialize, Serialize, Queryable, Insertable, Selectable)]
 #[diesel(table_name = rfd_revision)]
 pub struct RfdRevisionModel {
     pub id: Uuid,

--- a/rfd-model/src/lib.rs
+++ b/rfd-model/src/lib.rs
@@ -63,11 +63,15 @@ impl TypedUuidKind for RfdId {
 }
 
 #[partial(NewRfd)]
+#[partial(RfdMeta)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Rfd {
     pub id: TypedUuid<RfdId>,
     pub rfd_number: i32,
     pub link: Option<String>,
+    #[partial(NewRfd(skip))]
+    #[partial(RfdMeta(retype = RfdRevisionMeta))]
+    pub content: RfdRevision,
     #[partial(NewRfd(skip))]
     pub created_at: DateTime<Utc>,
     #[partial(NewRfd(skip))]
@@ -77,16 +81,32 @@ pub struct Rfd {
     pub visibility: Visibility,
 }
 
-impl From<RfdModel> for Rfd {
-    fn from(value: RfdModel) -> Self {
+impl From<(RfdModel, RfdRevisionModel)> for Rfd {
+    fn from((rfd, revision): (RfdModel, RfdRevisionModel)) -> Self {
         Self {
-            id: TypedUuid::from_untyped_uuid(value.id),
-            rfd_number: value.rfd_number,
-            link: value.link,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
-            deleted_at: value.deleted_at,
-            visibility: value.visibility,
+            id: TypedUuid::from_untyped_uuid(rfd.id),
+            rfd_number: rfd.rfd_number,
+            link: rfd.link,
+            content: revision.into(),
+            created_at: rfd.created_at,
+            updated_at: rfd.updated_at,
+            deleted_at: rfd.deleted_at,
+            visibility: rfd.visibility,
+        }
+    }
+}
+
+impl From<(RfdModel, RfdRevisionMetaModel)> for RfdMeta {
+    fn from((rfd, revision): (RfdModel, RfdRevisionMetaModel)) -> Self {
+        Self {
+            id: TypedUuid::from_untyped_uuid(rfd.id),
+            rfd_number: rfd.rfd_number,
+            link: rfd.link,
+            content: revision.into(),
+            created_at: rfd.created_at,
+            updated_at: rfd.updated_at,
+            deleted_at: rfd.deleted_at,
+            visibility: rfd.visibility,
         }
     }
 }

--- a/rfd-model/src/storage/mock.rs
+++ b/rfd-model/src/storage/mock.rs
@@ -1,0 +1,256 @@
+use async_trait::async_trait;
+use newtype_uuid::TypedUuid;
+use std::sync::Arc;
+use v_model::storage::StoreError;
+
+use crate::{
+    Job, NewJob, NewRfd, NewRfdPdf, NewRfdRevision, Rfd, RfdId, RfdMeta, RfdPdf, RfdPdfId,
+    RfdRevision, RfdRevisionId, RfdRevisionMeta,
+};
+
+use super::{
+    JobFilter, JobStore, ListPagination, MockJobStore, MockRfdMetaStore, MockRfdPdfStore,
+    MockRfdRevisionMetaStore, MockRfdRevisionStore, MockRfdStore, RfdFilter, RfdMetaStore,
+    RfdPdfFilter, RfdPdfStore, RfdRevisionFilter, RfdRevisionMetaStore, RfdRevisionStore, RfdStore,
+};
+
+pub struct MockStorage {
+    pub rfd_store: Option<Arc<MockRfdStore>>,
+    pub rfd_meta_store: Option<Arc<MockRfdMetaStore>>,
+    pub rfd_revision_store: Option<Arc<MockRfdRevisionStore>>,
+    pub rfd_revision_meta_store: Option<Arc<MockRfdRevisionMetaStore>>,
+    pub rfd_pdf_store: Option<Arc<MockRfdPdfStore>>,
+    pub job_store: Option<Arc<MockJobStore>>,
+}
+
+impl MockStorage {
+    pub fn new() -> Self {
+        Self {
+            rfd_store: None,
+            rfd_meta_store: None,
+            rfd_revision_store: None,
+            rfd_revision_meta_store: None,
+            rfd_pdf_store: None,
+            job_store: None,
+        }
+    }
+}
+
+#[async_trait]
+impl RfdStore for MockStorage {
+    async fn get(
+        &self,
+        id: &TypedUuid<RfdId>,
+        revision: Option<TypedUuid<RfdRevisionId>>,
+        deleted: bool,
+    ) -> Result<Option<Rfd>, StoreError> {
+        self.rfd_store
+            .as_ref()
+            .unwrap()
+            .get(id, revision, deleted)
+            .await
+    }
+
+    async fn list(
+        &self,
+        filter: RfdFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<Rfd>, StoreError> {
+        self.rfd_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+
+    async fn upsert(&self, new_rfd: NewRfd) -> Result<Rfd, StoreError> {
+        self.rfd_store.as_ref().unwrap().upsert(new_rfd).await
+    }
+
+    async fn delete(&self, id: &TypedUuid<RfdId>) -> Result<Option<Rfd>, StoreError> {
+        self.rfd_store.as_ref().unwrap().delete(id).await
+    }
+}
+
+#[async_trait]
+impl RfdMetaStore for MockStorage {
+    async fn get(
+        &self,
+        id: TypedUuid<RfdId>,
+        revision: Option<TypedUuid<RfdRevisionId>>,
+        deleted: bool,
+    ) -> Result<Option<RfdMeta>, StoreError> {
+        self.rfd_meta_store
+            .as_ref()
+            .unwrap()
+            .get(id, revision, deleted)
+            .await
+    }
+
+    async fn list(
+        &self,
+        filter: RfdFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<RfdMeta>, StoreError> {
+        self.rfd_meta_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+}
+
+#[async_trait]
+impl RfdRevisionStore for MockStorage {
+    async fn get(
+        &self,
+        id: &TypedUuid<RfdRevisionId>,
+        deleted: bool,
+    ) -> Result<Option<RfdRevision>, StoreError> {
+        self.rfd_revision_store
+            .as_ref()
+            .unwrap()
+            .get(id, deleted)
+            .await
+    }
+
+    async fn list(
+        &self,
+        filter: RfdRevisionFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<RfdRevision>, StoreError> {
+        self.rfd_revision_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+
+    async fn list_unique_rfd(
+        &self,
+        filter: RfdRevisionFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<RfdRevision>, StoreError> {
+        self.rfd_revision_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+
+    async fn upsert(&self, new_revision: NewRfdRevision) -> Result<RfdRevision, StoreError> {
+        self.rfd_revision_store
+            .as_ref()
+            .unwrap()
+            .upsert(new_revision)
+            .await
+    }
+
+    async fn delete(
+        &self,
+        id: &TypedUuid<RfdRevisionId>,
+    ) -> Result<Option<RfdRevision>, StoreError> {
+        self.rfd_revision_store.as_ref().unwrap().delete(id).await
+    }
+}
+
+#[async_trait]
+impl RfdRevisionMetaStore for MockStorage {
+    async fn get(
+        &self,
+        id: &TypedUuid<RfdRevisionId>,
+        deleted: bool,
+    ) -> Result<Option<RfdRevisionMeta>, StoreError> {
+        self.rfd_revision_meta_store
+            .as_ref()
+            .unwrap()
+            .get(id, deleted)
+            .await
+    }
+
+    async fn list(
+        &self,
+        filter: RfdRevisionFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<RfdRevisionMeta>, StoreError> {
+        self.rfd_revision_meta_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+
+    async fn list_unique_rfd(
+        &self,
+        filter: RfdRevisionFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<RfdRevisionMeta>, StoreError> {
+        self.rfd_revision_meta_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+}
+
+#[async_trait]
+impl RfdPdfStore for MockStorage {
+    async fn get(
+        &self,
+        id: &TypedUuid<RfdPdfId>,
+        deleted: bool,
+    ) -> Result<Option<RfdPdf>, StoreError> {
+        self.rfd_pdf_store.as_ref().unwrap().get(id, deleted).await
+    }
+
+    async fn list(
+        &self,
+        filter: RfdPdfFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<RfdPdf>, StoreError> {
+        self.rfd_pdf_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+
+    async fn upsert(&self, new_pdf: NewRfdPdf) -> Result<RfdPdf, StoreError> {
+        self.rfd_pdf_store.as_ref().unwrap().upsert(new_pdf).await
+    }
+
+    async fn delete(&self, id: &TypedUuid<RfdPdfId>) -> Result<Option<RfdPdf>, StoreError> {
+        self.rfd_pdf_store.as_ref().unwrap().delete(id).await
+    }
+}
+
+#[async_trait]
+impl JobStore for MockStorage {
+    async fn get(&self, id: i32) -> Result<Option<Job>, StoreError> {
+        self.job_store.as_ref().unwrap().get(id).await
+    }
+
+    async fn list(
+        &self,
+        filter: JobFilter,
+        pagination: &ListPagination,
+    ) -> Result<Vec<Job>, StoreError> {
+        self.job_store
+            .as_ref()
+            .unwrap()
+            .list(filter, pagination)
+            .await
+    }
+
+    async fn upsert(&self, new_job: NewJob) -> Result<Job, StoreError> {
+        self.job_store.as_ref().unwrap().upsert(new_job).await
+    }
+
+    async fn start(&self, id: i32) -> Result<Option<Job>, StoreError> {
+        self.job_store.as_ref().unwrap().start(id).await
+    }
+
+    async fn complete(&self, id: i32) -> Result<Option<Job>, StoreError> {
+        self.job_store.as_ref().unwrap().complete(id).await
+    }
+}

--- a/rfd-model/src/storage/mock.rs
+++ b/rfd-model/src/storage/mock.rs
@@ -57,13 +57,13 @@ impl RfdStore for MockStorage {
 
     async fn list(
         &self,
-        filter: RfdFilter,
+        filters: Vec<RfdFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<Rfd>, StoreError> {
         self.rfd_store
             .as_ref()
             .unwrap()
-            .list(filter, pagination)
+            .list(filters, pagination)
             .await
     }
 
@@ -93,13 +93,13 @@ impl RfdMetaStore for MockStorage {
 
     async fn list(
         &self,
-        filter: RfdFilter,
+        filters: Vec<RfdFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdMeta>, StoreError> {
         self.rfd_meta_store
             .as_ref()
             .unwrap()
-            .list(filter, pagination)
+            .list(filters, pagination)
             .await
     }
 }
@@ -120,25 +120,13 @@ impl RfdRevisionStore for MockStorage {
 
     async fn list(
         &self,
-        filter: RfdRevisionFilter,
+        filters: Vec<RfdRevisionFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdRevision>, StoreError> {
         self.rfd_revision_store
             .as_ref()
             .unwrap()
-            .list(filter, pagination)
-            .await
-    }
-
-    async fn list_unique_rfd(
-        &self,
-        filter: RfdRevisionFilter,
-        pagination: &ListPagination,
-    ) -> Result<Vec<RfdRevision>, StoreError> {
-        self.rfd_revision_store
-            .as_ref()
-            .unwrap()
-            .list(filter, pagination)
+            .list(filters, pagination)
             .await
     }
 
@@ -174,25 +162,13 @@ impl RfdRevisionMetaStore for MockStorage {
 
     async fn list(
         &self,
-        filter: RfdRevisionFilter,
+        filters: Vec<RfdRevisionFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdRevisionMeta>, StoreError> {
         self.rfd_revision_meta_store
             .as_ref()
             .unwrap()
-            .list(filter, pagination)
-            .await
-    }
-
-    async fn list_unique_rfd(
-        &self,
-        filter: RfdRevisionFilter,
-        pagination: &ListPagination,
-    ) -> Result<Vec<RfdRevisionMeta>, StoreError> {
-        self.rfd_revision_meta_store
-            .as_ref()
-            .unwrap()
-            .list(filter, pagination)
+            .list(filters, pagination)
             .await
     }
 }
@@ -209,13 +185,13 @@ impl RfdPdfStore for MockStorage {
 
     async fn list(
         &self,
-        filter: RfdPdfFilter,
+        filters: Vec<RfdPdfFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdPdf>, StoreError> {
         self.rfd_pdf_store
             .as_ref()
             .unwrap()
-            .list(filter, pagination)
+            .list(filters, pagination)
             .await
     }
 
@@ -236,13 +212,13 @@ impl JobStore for MockStorage {
 
     async fn list(
         &self,
-        filter: JobFilter,
+        filters: Vec<JobFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<Job>, StoreError> {
         self.job_store
             .as_ref()
             .unwrap()
-            .list(filter, pagination)
+            .list(filters, pagination)
             .await
     }
 

--- a/rfd-model/src/storage/mock.rs
+++ b/rfd-model/src/storage/mock.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use async_trait::async_trait;
 use newtype_uuid::TypedUuid;
 use std::sync::Arc;

--- a/rfd-model/src/storage/mod.rs
+++ b/rfd-model/src/storage/mod.rs
@@ -98,7 +98,7 @@ pub trait RfdStore {
     ) -> Result<Option<Rfd>, StoreError>;
     async fn list(
         &self,
-        filter: RfdFilter,
+        filters: Vec<RfdFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<Rfd>, StoreError>;
     async fn upsert(&self, new_rfd: NewRfd) -> Result<Rfd, StoreError>;
@@ -116,7 +116,7 @@ pub trait RfdMetaStore {
     ) -> Result<Option<RfdMeta>, StoreError>;
     async fn list(
         &self,
-        filter: RfdFilter,
+        filters: Vec<RfdFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdMeta>, StoreError>;
 }
@@ -171,14 +171,14 @@ pub trait RfdRevisionStore {
     ) -> Result<Option<RfdRevision>, StoreError>;
     async fn list(
         &self,
-        filter: RfdRevisionFilter,
+        filters: Vec<RfdRevisionFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdRevision>, StoreError>;
-    async fn list_unique_rfd(
-        &self,
-        filter: RfdRevisionFilter,
-        pagination: &ListPagination,
-    ) -> Result<Vec<RfdRevision>, StoreError>;
+    // async fn list_unique_rfd(
+    //     &self,
+    //     filters: Vec<RfdRevisionFilter>,
+    //     pagination: &ListPagination,
+    // ) -> Result<Vec<RfdRevision>, StoreError>;
     async fn upsert(&self, new_revision: NewRfdRevision) -> Result<RfdRevision, StoreError>;
     async fn delete(
         &self,
@@ -196,14 +196,14 @@ pub trait RfdRevisionMetaStore {
     ) -> Result<Option<RfdRevisionMeta>, StoreError>;
     async fn list(
         &self,
-        filter: RfdRevisionFilter,
+        filters: Vec<RfdRevisionFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdRevisionMeta>, StoreError>;
-    async fn list_unique_rfd(
-        &self,
-        filter: RfdRevisionFilter,
-        pagination: &ListPagination,
-    ) -> Result<Vec<RfdRevisionMeta>, StoreError>;
+    // async fn list_unique_rfd(
+    //     &self,
+    //     filter: RfdRevisionFilter,
+    //     pagination: &ListPagination,
+    // ) -> Result<Vec<RfdRevisionMeta>, StoreError>;
 }
 
 #[derive(Debug, Default)]
@@ -258,7 +258,7 @@ pub trait RfdPdfStore {
     ) -> Result<Option<RfdPdf>, StoreError>;
     async fn list(
         &self,
-        filter: RfdPdfFilter,
+        filters: Vec<RfdPdfFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<RfdPdf>, StoreError>;
     async fn upsert(&self, new_revision: NewRfdPdf) -> Result<RfdPdf, StoreError>;
@@ -301,7 +301,7 @@ pub trait JobStore {
     async fn get(&self, id: i32) -> Result<Option<Job>, StoreError>;
     async fn list(
         &self,
-        filter: JobFilter,
+        filters: Vec<JobFilter>,
         pagination: &ListPagination,
     ) -> Result<Vec<Job>, StoreError>;
     async fn upsert(&self, new_job: NewJob) -> Result<Job, StoreError>;

--- a/rfd-model/src/storage/mod.rs
+++ b/rfd-model/src/storage/mod.rs
@@ -12,8 +12,8 @@ use std::fmt::Debug;
 use v_model::storage::{ListPagination, StoreError};
 
 use crate::{
-    schema_ext::PdfSource, Job, NewJob, NewRfd, NewRfdPdf, NewRfdRevision, Rfd, RfdId, RfdMeta,
-    RfdPdf, RfdPdfId, RfdRevision, RfdRevisionId, RfdRevisionMeta,
+    schema_ext::PdfSource, CommitSha, Job, NewJob, NewRfd, NewRfdPdf, NewRfdRevision, Rfd, RfdId,
+    RfdMeta, RfdPdf, RfdPdfId, RfdRevision, RfdRevisionId, RfdRevisionMeta,
 };
 
 #[cfg(feature = "mock")]
@@ -50,7 +50,7 @@ pub struct RfdFilter {
     pub id: Option<Vec<TypedUuid<RfdId>>>,
     pub revision: Option<Vec<TypedUuid<RfdRevisionId>>>,
     pub rfd_number: Option<Vec<i32>>,
-    pub sha: Option<Vec<String>>,
+    pub commit: Option<Vec<CommitSha>>,
     pub public: Option<bool>,
     pub deleted: bool,
 }
@@ -71,8 +71,8 @@ impl RfdFilter {
         self
     }
 
-    pub fn sha(mut self, sha: Option<Vec<String>>) -> Self {
-        self.sha = sha;
+    pub fn commit(mut self, commit: Option<Vec<CommitSha>>) -> Self {
+        self.commit = commit;
         self
     }
 
@@ -128,7 +128,7 @@ pub trait RfdMetaStore {
 pub struct RfdRevisionFilter {
     pub id: Option<Vec<TypedUuid<RfdRevisionId>>>,
     pub rfd: Option<Vec<TypedUuid<RfdId>>>,
-    pub sha: Option<Vec<String>>,
+    pub commit: Option<Vec<CommitSha>>,
     pub deleted: bool,
 }
 
@@ -143,8 +143,8 @@ impl RfdRevisionFilter {
         self
     }
 
-    pub fn sha(mut self, sha: Option<Vec<String>>) -> Self {
-        self.sha = sha;
+    pub fn commit(mut self, commit: Option<Vec<CommitSha>>) -> Self {
+        self.commit = commit;
         self
     }
 

--- a/rfd-model/src/storage/postgres.rs
+++ b/rfd-model/src/storage/postgres.rs
@@ -72,7 +72,7 @@ impl RfdStore for PostgresStore {
                     id,
                     revision,
                     rfd_number,
-                    sha,
+                    commit,
                     public,
                     deleted,
                 } = filter;
@@ -94,8 +94,10 @@ impl RfdStore for PostgresStore {
                     predicates.push(Box::new(rfd::rfd_number.eq_any(rfd_number)));
                 }
 
-                if let Some(sha) = sha {
-                    predicates.push(Box::new(rfd_revision::sha.eq_any(sha)));
+                if let Some(commit) = commit {
+                    predicates.push(Box::new(
+                        rfd_revision::commit_sha.eq_any(commit.into_iter().map(|sha| sha.0)),
+                    ));
                 }
 
                 if let Some(public) = public {
@@ -212,7 +214,7 @@ impl RfdMetaStore for PostgresStore {
                     id,
                     revision,
                     rfd_number,
-                    sha,
+                    commit,
                     public,
                     deleted,
                 } = filter;
@@ -234,8 +236,10 @@ impl RfdMetaStore for PostgresStore {
                     predicates.push(Box::new(rfd::rfd_number.eq_any(rfd_number)));
                 }
 
-                if let Some(sha) = sha {
-                    predicates.push(Box::new(rfd_revision::sha.eq_any(sha)));
+                if let Some(commit) = commit {
+                    predicates.push(Box::new(
+                        rfd_revision::commit_sha.eq_any(commit.into_iter().map(|sha| sha.0)),
+                    ));
                 }
 
                 if let Some(public) = public {
@@ -309,7 +313,7 @@ impl RfdRevisionStore for PostgresStore {
                 let RfdRevisionFilter {
                     id,
                     rfd,
-                    sha,
+                    commit,
                     deleted,
                 } = filter;
 
@@ -326,8 +330,10 @@ impl RfdRevisionStore for PostgresStore {
                     ));
                 }
 
-                if let Some(sha) = sha {
-                    predicates.push(Box::new(rfd_revision::sha.eq_any(sha)));
+                if let Some(commit) = commit {
+                    predicates.push(Box::new(
+                        rfd_revision::commit_sha.eq_any(commit.into_iter().map(|sha| sha.0)),
+                    ));
                 }
 
                 if !deleted {
@@ -462,7 +468,7 @@ impl RfdRevisionMetaStore for PostgresStore {
                 let RfdRevisionFilter {
                     id,
                     rfd,
-                    sha,
+                    commit,
                     deleted,
                 } = filter;
 
@@ -479,8 +485,10 @@ impl RfdRevisionMetaStore for PostgresStore {
                     ));
                 }
 
-                if let Some(sha) = sha {
-                    predicates.push(Box::new(rfd_revision::sha.eq_any(sha)));
+                if let Some(commit) = commit {
+                    predicates.push(Box::new(
+                        rfd_revision::commit_sha.eq_any(commit.into_iter().map(|sha| sha.0)),
+                    ));
                 }
 
                 if !deleted {

--- a/rfd-processor/src/context.rs
+++ b/rfd-processor/src/context.rs
@@ -19,7 +19,7 @@ use octorust::{
 };
 use reqwest::Error as ReqwestError;
 use rfd_github::{GitHubError, GitHubRfdRepo};
-use rfd_model::{schema_ext::PdfSource, storage::postgres::PostgresStore};
+use rfd_model::schema_ext::PdfSource;
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, EncodeRsaPrivateKey},
     RsaPrivateKey,
@@ -27,6 +27,7 @@ use rsa::{
 use tap::TapFallible;
 use thiserror::Error;
 use tracing::instrument;
+use v_model::storage::postgres::PostgresStore;
 
 use crate::{
     pdf::{PdfFileLocation, PdfStorage, RfdPdf, RfdPdfError},

--- a/rfd-processor/src/processor.rs
+++ b/rfd-processor/src/processor.rs
@@ -34,9 +34,9 @@ pub async fn processor(ctx: Arc<Context>) -> Result<(), JobError> {
         if ctx.processor.enabled {
             let jobs = JobStore::list(
                 &ctx.db.storage,
-                JobFilter::default()
+                vec![JobFilter::default()
                     .processed(Some(false))
-                    .started(Some(false)),
+                    .started(Some(false))],
                 &pagination,
             )
             .await?;

--- a/rfd-processor/src/rfd.rs
+++ b/rfd-processor/src/rfd.rs
@@ -347,7 +347,7 @@ impl RemoteRfd {
             storage,
             vec![RfdRevisionFilter::default()
                 .rfd(Some(vec![rfd.id]))
-                .sha(Some(vec![payload.commit_sha.clone().into()]))],
+                .commit(Some(vec![payload.commit_sha.clone()]))],
             &ListPagination::latest(),
         )
         .await?
@@ -387,7 +387,7 @@ impl RemoteRfd {
                 content: payload.content.raw().to_string(),
                 content_format: payload.content_format,
                 sha: payload.sha,
-                commit: payload.commit_sha.into(),
+                commit: payload.commit_sha,
                 committed_at: payload.commit_date,
             },
         )

--- a/rfd-processor/src/rfd.rs
+++ b/rfd-processor/src/rfd.rs
@@ -56,7 +56,7 @@ impl PersistedRfd {
     {
         let existing_rfd = RfdStore::list(
             storage,
-            RfdFilter::default().rfd_number(Some(vec![number.into()])),
+            vec![RfdFilter::default().rfd_number(Some(vec![number.into()]))],
             &ListPagination::latest(),
         )
         .await?
@@ -66,7 +66,7 @@ impl PersistedRfd {
         if let Some(rfd) = existing_rfd {
             let most_recent_revision = RfdRevisionStore::list(
                 storage,
-                RfdRevisionFilter::default().rfd(Some(vec![rfd.id])),
+                vec![RfdRevisionFilter::default().rfd(Some(vec![rfd.id]))],
                 &ListPagination::latest(),
             )
             .await?
@@ -75,7 +75,7 @@ impl PersistedRfd {
 
             let most_recent_pdf = RfdPdfStore::list(
                 storage,
-                RfdPdfFilter::default().rfd(Some(vec![rfd.id])),
+                vec![RfdPdfFilter::default().rfd(Some(vec![rfd.id]))],
                 &ListPagination::latest(),
             )
             .await?
@@ -323,7 +323,7 @@ impl RemoteRfd {
 
         let (id, visibility) = RfdStore::list(
             storage,
-            RfdFilter::default().rfd_number(Some(vec![payload.number.into()])),
+            vec![RfdFilter::default().rfd_number(Some(vec![payload.number.into()]))],
             &ListPagination::latest(),
         )
         .await?
@@ -345,9 +345,9 @@ impl RemoteRfd {
 
         let id = RfdRevisionStore::list(
             storage,
-            RfdRevisionFilter::default()
+            vec![RfdRevisionFilter::default()
                 .rfd(Some(vec![rfd.id]))
-                .sha(Some(vec![payload.commit_sha.clone().into()])),
+                .sha(Some(vec![payload.commit_sha.clone().into()]))],
             &ListPagination::latest(),
         )
         .await?
@@ -395,7 +395,7 @@ impl RemoteRfd {
 
         let mut existing_pdf = RfdPdfStore::list(
             storage,
-            RfdPdfFilter::default().rfd(Some(vec![rfd.id])),
+            vec![RfdPdfFilter::default().rfd(Some(vec![rfd.id]))],
             &ListPagination::latest(),
         )
         .await?;


### PR DESCRIPTION
Splits out rfd metadata from rfd revisions on the backend and pushes revision queries down to the database layer as oppose to the api layer.