### PR TITLE
is_major_change: Skip format changes

### DIFF
--- a/rfd-processor/src/updater/mod.rs
+++ b/rfd-processor/src/updater/mod.rs
@@ -381,5 +381,6 @@ pub enum RfdUpdateActionErr {
 }
 
 fn is_major_change(old: &RfdContent, new: &RfdContent) -> bool {
-    old.body() != new.body() || old.get_state() != new.get_state()
+    // Major if body or state changes; unless format changed (e.g. .md -> .adoc)
+    old.format() == new.format() && (old.body() != new.body() || old.get_state() != new.get_state())
 }


### PR DESCRIPTION
This is so that format conversions (md->adoc) won't be seen as a major version change when calculated the "Updated" field. Existing commits which have already been processed will have to be manually altered in the database.

See also: 
- https://github.com/oxidecomputer/rfd/issues/1035

Alternatively I could just merge all those changes, and update everything manually and not merge this PR. I don't have strong feelings.