### PR TITLE
ci: Add test to validate generated SDK hasn't drifted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,40 @@ jobs:
         env:
           TEST_DATABASE: postgres://test:test@localhost
           RUST_LOG: v=trace,rfd=trace
+
+  generate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          rustup toolchain install
+          rustup toolchain install nightly --component rustfmt
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install Dprint
+        run: |
+          mkdir -p "$HOME/.dprint/bin"
+          curl -fsSL \
+            "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/${DPRINT_ASSET}" \
+            > "$HOME/.dprint/bin/${DPRINT_ASSET}"
+          cd "$HOME/.dprint/bin"
+          echo "${DPRINT_HASH}  ${DPRINT_ASSET}" | sha256sum --check
+          unzip "${DPRINT_ASSET}"
+          rm "${DPRINT_ASSET}"
+          echo "/home/runner/.dprint/bin" >> $GITHUB_PATH
+        env:
+          DPRINT_VERSION: 0.53.0
+          DPRINT_HASH: 987185f5f0db6205e5bca88aaab04a7b29bc18bf7a8c1a84f56eef08c9730df0
+          DPRINT_ASSET: dprint-x86_64-unknown-linux-gnu.zip
+
+      - name: Verify SDK Generation
+        run: |
+          cargo xtask generate
+          GENERATED="rfd-sdk/src/generated/ rfd-cli/src/generated/ rfd-ts/"
+          if ! git diff --quiet -- $GENERATED; then
+            git diff -- $GENERATED
+            echo "Found changed files after generating SDKs:"
+            git status -s -- $GENERATED
+            echo "To fix, regenerate with, commit the changes from running:"
+            echo "  cargo xtask generate"
+            exit 1
+          fi

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -236,6 +236,19 @@ fn generate(check: bool, verbose: bool) -> Result<(), String> {
         .map_err(|err| err.to_string())?;
     println!("done.");
 
+    // The generator's parseIfDate heuristic doesn't include `_at` suffixes,
+    // but our API uses fields like created_at, updated_at, expires_at.
+    let util_path = xtask_path.parent().unwrap().join("rfd-ts/src/util.ts");
+    let util_contents = fs::read_to_string(&util_path).map_err(|e| e.to_string())?;
+    let patched = util_contents.replace(
+        r#"k?.endsWith("_expiration")"#,
+        "k?.endsWith(\"_expiration\") ||\n      k?.endsWith(\"_at\")",
+    );
+    if patched == util_contents {
+        return Err("Failed to patch util.ts: could not find _expiration pattern".to_string());
+    }
+    fs::write(&util_path, patched).map_err(|e| e.to_string())?;
+
     print!("formatting typescript sdk ... ");
     Command::new("dprint")
         .arg("fmt")


### PR DESCRIPTION
In CI ensure the generated SDKs match the current source. 

Borrow workaround from https://github.com/oxidecomputer/turnstile/pull/357 as otherwise [oxide/openapi-gen-ts](https://github.com/oxidecomputer/oxide.ts/tree/main/oxide-openapi-gen-ts) will treat `_at` columns as strings rather than datetime.  Previously this edit was applied manually.