### PR TITLE
Rust 2024; Unify Cargo.toml workspace settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "parse-rfd"
-version = "0.1.0"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rfd-data"
-version = "0.1.0"
+version = "0.14.1"
 dependencies = [
  "regex",
  "rfd-model",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "rfd-github"
-version = "0.1.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "rfd-installer"
-version = "0.1.0"
+version = "0.14.1"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "rfd-model"
-version = "0.1.0"
+version = "0.14.1"
 dependencies = [
  "async-bb8-diesel",
  "async-trait",
@@ -4870,7 +4870,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "trace-request"
-version = "0.1.0"
+version = "0.14.1"
 dependencies = [
  "dropshot",
  "http 1.4.0",
@@ -5817,7 +5817,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtask"
-version = "0.0.0"
+version = "0.14.1"
 dependencies = [
  "clap",
  "newline-converter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.14.1"
+edition = "2024"
+
 [workspace.dependencies]
 anyhow = "1.0.102"
 async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", version = "0.3" }

--- a/parse-rfd/Cargo.toml
+++ b/parse-rfd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parse-rfd"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rfd-api/Cargo.toml
+++ b/rfd-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-api"
-version = "0.14.1"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 repository = "https://github.com/oxidecomputer/rfd-api"
 
 [features]

--- a/rfd-api/src/context.rs
+++ b/rfd-api/src/context.rs
@@ -1019,7 +1019,7 @@ pub(crate) mod test_mocks {
             }),
         );
 
-        let ctx = RfdContext::new(
+        RfdContext::new(
             "".to_string(),
             Arc::new(storage),
             SearchConfig::default(),
@@ -1038,8 +1038,6 @@ pub(crate) mod test_mocks {
             v_context,
         )
         .await
-        .unwrap();
-
-        ctx
+        .unwrap()
     }
 }

--- a/rfd-api/src/endpoints/rfd.rs
+++ b/rfd-api/src/endpoints/rfd.rs
@@ -1118,7 +1118,7 @@ mod tests {
             ];
 
             results.retain(|rfd| {
-                filter.len() == 0
+                filter.is_empty()
                     || filter[0].rfd_number.is_none()
                     || filter[0]
                         .rfd_number
@@ -1217,7 +1217,7 @@ mod tests {
             ];
 
             results.retain(|rfd| {
-                filter.len() == 0
+                filter.is_empty()
                     || filter[0].rfd_number.is_none()
                     || filter[0]
                         .rfd_number
@@ -1360,7 +1360,7 @@ mod tests {
                 ];
 
                 results.retain(|revision| {
-                    filter.len() == 0
+                    filter.is_empty()
                         || filter[0].rfd.is_none()
                         || filter[0].rfd.as_ref().unwrap().contains(&revision.rfd_id)
                 });

--- a/rfd-api/src/secrets.rs
+++ b/rfd-api/src/secrets.rs
@@ -25,7 +25,7 @@ impl JsonSchema for OpenApiSecretString {
         true
     }
 
-    fn json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         SchemaObject {
             instance_type: Some(InstanceType::String.into()),
             ..Default::default()

--- a/rfd-cli/Cargo.toml
+++ b/rfd-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-cli"
-version = "0.14.1"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 [features]
 local-dev = []

--- a/rfd-cli/build.rs
+++ b/rfd-cli/build.rs
@@ -75,17 +75,17 @@ fn schema_to_entry(schema: &Value) -> Option<String> {
             "<rfd_sdk::types::{rust} as schemars::JsonSchema>::schema_name()"
         ));
     }
-    if schema.get("type").and_then(Value::as_str) == Some("array") {
-        if let Some(r) = schema.pointer("/items/$ref").and_then(Value::as_str) {
-            let rust = strip_underscores(&ref_tail(r));
-            return Some(format!(
-                "<Vec<rfd_sdk::types::{rust}> as schemars::JsonSchema>::schema_name()"
-            ));
-        }
-        // Inline arrays without a `$ref` items target (e.g. `Vec<u8>`) have no
-        // matching `rfd_sdk::types::*` to reference. The dispatch table is not
-        // expected to cover them, so we skip rather than emit.
+    if schema.get("type").and_then(Value::as_str) == Some("array")
+        && let Some(r) = schema.pointer("/items/$ref").and_then(Value::as_str)
+    {
+        let rust = strip_underscores(&ref_tail(r));
+        return Some(format!(
+            "<Vec<rfd_sdk::types::{rust}> as schemars::JsonSchema>::schema_name()"
+        ));
     }
+    // Inline arrays without a `$ref` items target (e.g. `Vec<u8>`) have no
+    // matching `rfd_sdk::types::*` to reference. The dispatch table is not
+    // expected to cover them, so we skip rather than emit.
     None
 }
 

--- a/rfd-data/Cargo.toml
+++ b/rfd-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-data"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rfd-data/src/content/asciidoc.rs
+++ b/rfd-data/src/content/asciidoc.rs
@@ -72,12 +72,11 @@ impl<'a> RfdAsciidoc<'a> {
     }
 
     fn apply_author_line_attributes(content: &mut String) {
-        if let Some(author_line) = Self::author_line(content) {
-            if let Some(authors) = RfdAuthors::parse(author_line) {
-                if !authors.0.is_empty() {
-                    *content = Self::set_attr(content, "authors", &authors.into_attr());
-                }
-            }
+        if let Some(author_line) = Self::author_line(content)
+            && let Some(authors) = RfdAuthors::parse(author_line)
+            && !authors.0.is_empty()
+        {
+            *content = Self::set_attr(content, "authors", &authors.into_attr());
         }
     }
 
@@ -455,67 +454,67 @@ mod tests {
     fn test_single_author() {
         let line = "firstname";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
-        assert_eq!(authors.0.get(0).unwrap().middle_name, None);
-        assert_eq!(authors.0.get(0).unwrap().last_name, None);
-        assert_eq!(authors.0.get(0).unwrap().email, None);
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().middle_name, None);
+        assert_eq!(authors.0.first().unwrap().last_name, None);
+        assert_eq!(authors.0.first().unwrap().email, None);
         let line = "firstname <email@company.com>";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
-        assert_eq!(authors.0.get(0).unwrap().middle_name, None);
-        assert_eq!(authors.0.get(0).unwrap().last_name, None);
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().middle_name, None);
+        assert_eq!(authors.0.first().unwrap().last_name, None);
         assert_eq!(
-            authors.0.get(0).unwrap().email.as_deref(),
+            authors.0.first().unwrap().email.as_deref(),
             Some("email@company.com")
         );
 
         let line = "firstname lastname";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
-        assert_eq!(authors.0.get(0).unwrap().middle_name, None);
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().middle_name, None);
         assert_eq!(
-            authors.0.get(0).unwrap().last_name.as_deref(),
+            authors.0.first().unwrap().last_name.as_deref(),
             Some("lastname")
         );
-        assert_eq!(authors.0.get(0).unwrap().email, None);
+        assert_eq!(authors.0.first().unwrap().email, None);
         let line = "firstname lastname <email@company.com>";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
-        assert_eq!(authors.0.get(0).unwrap().middle_name, None);
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().middle_name, None);
         assert_eq!(
-            authors.0.get(0).unwrap().last_name.as_deref(),
+            authors.0.first().unwrap().last_name.as_deref(),
             Some("lastname")
         );
         assert_eq!(
-            authors.0.get(0).unwrap().email.as_deref(),
+            authors.0.first().unwrap().email.as_deref(),
             Some("email@company.com")
         );
 
         let line = "firstname middlename lastname";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
         assert_eq!(
-            authors.0.get(0).unwrap().middle_name.as_deref(),
+            authors.0.first().unwrap().middle_name.as_deref(),
             Some("middlename")
         );
         assert_eq!(
-            authors.0.get(0).unwrap().last_name.as_deref(),
+            authors.0.first().unwrap().last_name.as_deref(),
             Some("lastname")
         );
-        assert_eq!(authors.0.get(0).unwrap().email, None);
+        assert_eq!(authors.0.first().unwrap().email, None);
         let line = "firstname middlename lastname <email@company.com>";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
         assert_eq!(
-            authors.0.get(0).unwrap().middle_name.as_deref(),
+            authors.0.first().unwrap().middle_name.as_deref(),
             Some("middlename")
         );
         assert_eq!(
-            authors.0.get(0).unwrap().last_name.as_deref(),
+            authors.0.first().unwrap().last_name.as_deref(),
             Some("lastname")
         );
         assert_eq!(
-            authors.0.get(0).unwrap().email.as_deref(),
+            authors.0.first().unwrap().email.as_deref(),
             Some("email@company.com")
         );
     }
@@ -524,17 +523,17 @@ mod tests {
     fn test_author_trailing_semicolon() {
         let line = "firstname middlename lastname <email@company.com>;";
         let authors = RfdAuthors::parse(line).unwrap();
-        assert_eq!(authors.0.get(0).unwrap().first_name, "firstname");
+        assert_eq!(authors.0.first().unwrap().first_name, "firstname");
         assert_eq!(
-            authors.0.get(0).unwrap().middle_name.as_deref(),
+            authors.0.first().unwrap().middle_name.as_deref(),
             Some("middlename")
         );
         assert_eq!(
-            authors.0.get(0).unwrap().last_name.as_deref(),
+            authors.0.first().unwrap().last_name.as_deref(),
             Some("lastname")
         );
         assert_eq!(
-            authors.0.get(0).unwrap().email.as_deref(),
+            authors.0.first().unwrap().email.as_deref(),
             Some("email@company.com")
         );
     }
@@ -545,7 +544,7 @@ mod tests {
 
         let authors = RfdAuthors::parse(line).unwrap();
         let expected = r#"First2 M2 Last2 \"#.to_string();
-        assert_eq!(expected, authors.0.get(0).unwrap().first_name);
+        assert_eq!(expected, authors.0.first().unwrap().first_name);
     }
 
     // Reference resolution tests
@@ -558,7 +557,7 @@ mod tests {
 dsfsdf
 sdf"#;
         let rfd = RfdAsciidoc::new(content).unwrap();
-        assert!(rfd.content.to_string() != rfd.resolved);
+        assert!(rfd.content != rfd.resolved);
         assert!(!rfd.resolved.contains("{authors}"));
     }
 
@@ -967,7 +966,7 @@ FirstName LastName <fname@company.org>
 
 This is the new body"#;
         let mut rfd = RfdAsciidoc::new(Cow::Borrowed(test_rfd_content())).unwrap();
-        rfd.update_body(&new_content).unwrap();
+        rfd.update_body(new_content).unwrap();
         assert_eq!(expected, rfd.raw());
     }
 

--- a/rfd-github/Cargo.toml
+++ b/rfd-github/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-github"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rfd-installer/Cargo.toml
+++ b/rfd-installer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-installer"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "rfd_installer"

--- a/rfd-model/Cargo.toml
+++ b/rfd-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-model"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rfd-model/src/storage/mock.rs
+++ b/rfd-model/src/storage/mock.rs
@@ -30,6 +30,12 @@ pub struct MockStorage {
     pub job_store: Option<Arc<MockJobStore>>,
 }
 
+impl Default for MockStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockStorage {
     pub fn new() -> Self {
         Self {

--- a/rfd-processor/Cargo.toml
+++ b/rfd-processor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-processor"
-version = "0.14.1"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rfd-processor/src/util.rs
+++ b/rfd-processor/src/util.rs
@@ -132,7 +132,7 @@ pub mod test_util {
 
     #[allow(dead_code)]
     pub fn start_tracing() {
-        let _subscriber = tracing_subscriber::fmt()
+        tracing_subscriber::fmt()
             .with_file(false)
             .with_line_number(false)
             .with_env_filter(EnvFilter::from_default_env())

--- a/rfd-sdk/Cargo.toml
+++ b/rfd-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfd-sdk"
-version = "0.14.1"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+style_edition = "2021"
+edition = "2024"

--- a/trace-request/Cargo.toml
+++ b/trace-request/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trace-request"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
-version = "0.0.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 clap = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,10 +22,8 @@ use similar::{Algorithm, ChangeTag, TextDiff};
 #[command(about = "build tasks")]
 enum Xtask {
     #[command(about = "bump the global version number")]
-    Bump {
-        #[clap(long)]
-        place: VersionPlace,
-    },
+    #[command(arg_required_else_help = true)]
+    Bump { place: VersionPlace },
     #[command(about = "generate RFD sdk")]
     Generate {
         #[clap(long)]
@@ -37,8 +35,8 @@ enum Xtask {
 
 #[derive(Clone, ValueEnum)]
 enum VersionPlace {
-    Minor,
     Major,
+    Minor,
     Patch,
     Pre,
 }
@@ -53,26 +51,22 @@ fn main() -> Result<(), String> {
 }
 
 fn bump_package_versions(place: &VersionPlace) -> Result<(), String> {
-    let rust_crates = vec!["rfd-api", "rfd-processor", "rfd-sdk", "rfd-cli"];
     let node_package = vec!["rfd-ts"];
 
     let crate_version_pattern = Regex::new(r#"(?m)^version = "(.*)"$"#).unwrap();
 
-    for rust_crate in rust_crates {
-        let path = format!("{}/Cargo.toml", rust_crate);
-        let contents = fs::read_to_string(&path).unwrap();
-        let version_line = crate_version_pattern.captures(&contents).unwrap();
-        let mut version: Version = version_line.get(1).unwrap().as_str().parse().unwrap();
-        version = version.up(place);
+    let contents = fs::read_to_string("Cargo.toml").unwrap();
+    let version_line = crate_version_pattern.captures(&contents).unwrap();
+    let mut version: Version = version_line.get(1).unwrap().as_str().parse().unwrap();
+    version = version.up(place);
 
-        let old_version_line = version_line.get(0).unwrap().as_str();
-        let new_version_line = format!(r#"version = "{}""#, version);
-        let new_contents = contents.replace(old_version_line, &new_version_line);
+    let old_version_line = version_line.get(0).unwrap().as_str();
+    let new_version_line = format!(r#"version = "{}""#, version);
+    let new_contents = contents.replace(old_version_line, &new_version_line);
 
-        fs::write(path, new_contents).unwrap();
+    fs::write("Cargo.toml", new_contents).unwrap();
 
-        println!("Updated {} to {}", rust_crate, version);
-    }
+    println!("Updated workspace to {}", version);
 
     for node_package in node_package {
         let path = format!("{}/package.json", node_package);
@@ -97,6 +91,15 @@ fn bump_package_versions(place: &VersionPlace) -> Result<(), String> {
         fs::write(path, serde_json::to_string_pretty(&parsed).unwrap()).unwrap();
 
         println!("Updated {} to {}", node_package, version);
+    }
+
+    println!("Running cargo check to update Cargo.lock...");
+    let status = Command::new("cargo")
+        .args(["check", "-q"])
+        .status()
+        .map_err(|e| format!("Failed to run cargo check: {}", e))?;
+    if !status.success() {
+        return Err("cargo check failed".to_string());
     }
 
     Ok(())


### PR DESCRIPTION
- Switch to Rust 2024 Edition
- Add rustfmt.toml to pin to StyleEdition 2021
- Add `version = `, `edition = ` and `edition = ` --> `{ workspace = true }` for workspace crates
- Switch from `cargo xtask bump --place patch` to `cargo xtask bump patch`
- Fix Clippy warnings new in 2024 Edition