### PR TITLE
ci: Enforce clippy; release notes; Fix local-dev feature

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+changelog:
+  categories:
+    - title: Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependency Updates
+      labels:
+        - dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,14 +14,12 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: cargo fmt --all -- --check
-        run: cargo fmt --all -- --check
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          cargo fmt --all -- --check
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: cargo clippy -- -Dwarnings
-        run: cargo clippy -- -Dwarnings
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          cargo clippy --all-features --workspace --all-targets -- -Dwarnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           echo "${DPRINT_HASH}  ${DPRINT_ASSET}" | sha256sum --check
           unzip "${DPRINT_ASSET}"
           rm "${DPRINT_ASSET}"
-          echo "/home/runner/.dprint/bin" >> $GITHUB_PATH
+          echo "/home/runner/.dprint/bin" >> "$GITHUB_PATH"
         env:
           DPRINT_VERSION: 0.53.0
           DPRINT_HASH: 987185f5f0db6205e5bca88aaab04a7b29bc18bf7a8c1a84f56eef08c9730df0
@@ -84,10 +84,10 @@ jobs:
         run: |
           cargo xtask generate
           GENERATED="rfd-sdk/src/generated/ rfd-cli/src/generated/ rfd-ts/"
-          if ! git diff --quiet -- $GENERATED; then
-            git diff -- $GENERATED
+          if ! git diff --quiet -- "$GENERATED"; then
+            git diff -- "$GENERATED"
             echo "Found changed files after generating SDKs:"
-            git status -s -- $GENERATED
+            git status -s -- "$GENERATED"
             echo "To fix, regenerate with, commit the changes from running:"
             echo "  cargo xtask generate"
             exit 1

--- a/rfd-cli/src/cmd/auth/login.rs
+++ b/rfd-cli/src/cmd/auth/login.rs
@@ -5,11 +5,12 @@
 use std::ops::Add;
 
 use anyhow::Result;
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::{Duration, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
-use futures::stream::StreamExt;
 use oauth2::{basic::BasicTokenType, EmptyExtraTokenFields, StandardTokenResponse, TokenResponse};
 use rfd_sdk::types::OAuthProviderName;
+#[cfg(feature = "local-dev")]
+use serde::Serialize;
 
 use crate::{cmd::auth::oauth, Context};
 
@@ -66,10 +67,16 @@ pub enum AuthenticationMode {
 pub struct OAuthProviderRunner(OAuthProviderName);
 
 #[cfg(feature = "local-dev")]
-
 pub struct LocalProviderRunner {
     email: String,
     external_id: String,
+}
+
+#[cfg(feature = "local-dev")]
+#[derive(Serialize)]
+struct LocalLoginBody<'a> {
+    external_id: &'a str,
+    email: &'a str,
 }
 
 pub trait ProviderRunner {
@@ -119,34 +126,29 @@ impl ProviderRunner for OAuthProviderRunner {
 }
 
 #[cfg(feature = "local-dev")]
-
 impl ProviderRunner for LocalProviderRunner {
     async fn run(&self, ctx: &mut Context, mode: &AuthenticationMode) -> Result<String> {
-        let identity_token = ctx
-            .client()?
-            .local_login()
-            .body_map(|body| {
-                body.email(self.email.clone())
-                    .external_id(self.external_id.clone())
+        // The `/login/local` endpoint is registered by v-api only when its
+        // `local-dev` feature is enabled, so it is not present in the public
+        // OpenAPI spec and not exposed through the generated SDK. Hit it
+        // directly via reqwest instead.
+        let host = ctx.config.host()?;
+        let url = format!("{}/login/local", host.trim_end_matches('/'));
+
+        let response = reqwest::Client::new()
+            .post(&url)
+            .json(&LocalLoginBody {
+                external_id: &self.external_id,
+                email: &self.email,
             })
             .send()
             .await?
-            .into_inner();
+            .error_for_status()?
+            .json::<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>>()
+            .await
+            .map_err(|err| anyhow::anyhow!("Authentication failed: {}", err))?;
 
-        let mut bytes = identity_token.into_inner();
-
-        let mut data = vec![];
-        while let Some(chunk) = bytes.next().await {
-            data.append(&mut chunk?.to_vec());
-        }
-
-        let identity_token = match serde_json::from_slice::<
-            StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
-        >(&data)
-        {
-            Ok(token) => Ok(token.access_token().to_owned()),
-            Err(err) => Err(anyhow::anyhow!("Authentication failed: {}", err)),
-        }?;
+        let identity_token = response.access_token().to_owned();
 
         if mode == &AuthenticationMode::Token {
             let client = ctx.new_client(Some(identity_token.secret()))?;

--- a/rfd-cli/src/main.rs
+++ b/rfd-cli/src/main.rs
@@ -218,8 +218,6 @@ fn cmd_path<'a>(cmd: &CliCommand) -> Option<&'a str> {
         CliCommand::GetDeviceProvider => None,
         CliCommand::MagicLinkSend => None,
         CliCommand::MagicLinkExchange => None,
-        #[cfg(feature = "local-dev")]
-        CliCommand::LocalLogin => None,
 
         // Unsupported commands
         CliCommand::AuthzCodeRedirect => None,


### PR DESCRIPTION
- Expand clippy enforcement to include `--all-features --workspace --all-targets`
- Fix Clippy warnings
- Fix local-dev feature (broken in main for a while, discovered running Clippy)
- Fix trivial Actionlint warnings
- Add .github/release.yml -- Groups dependency changes together in release notes 