### PR TITLE
ci: Tweak release build workflows

### DIFF
--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -3,7 +3,7 @@ name: Release rfd-api
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     types: [labeled, synchronize]
 

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -3,7 +3,7 @@ name: Release rfd-api
 on:
   push:
     tags:
-      - "**[0-9]+.[0-9]+.[0-9]+*"
+      - "v*.*.*"
   pull_request:
     types: [labeled, synchronize]
 
@@ -14,12 +14,9 @@ concurrency:
 jobs:
   release:
     if: >-
-      github.repository_owner == 'oxidecomputer' && (
-        github.event_name == 'push' ||
-        github.event.label.name == 'release-test' ||
-        contains(github.event.pull_request.labels.*.name, 'release-test')
-      )
-
+      github.event_name == 'push' ||
+      github.event.label.name == 'release-test' ||
+      contains(github.event.pull_request.labels.*.name, 'release-test')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -36,17 +33,25 @@ jobs:
             echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
+      # Do this first, to avoid racing with release.yml
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@caacf56b56ba217c4eaf0a9deb59dbcdd12abfcd
+        with:
+          allowUpdates: true
+          draft: ${{ github.event_name == 'pull_request' }}
+          tag: ${{ steps.tag.outputs.value }}
+          generateReleaseNotes: true
+          prerelease: ${{ contains(steps.tag.outputs.value, '-pre') }}
+
       - run: |
           rustup toolchain install
 
       - name: Build Release Binary
         run: |
-          cargo build --release --package rfd-api
+          cargo build --release --package rfd-api --no-default-features
 
-      - uses: ncipollo/release-action@caacf56b56ba217c4eaf0a9deb59dbcdd12abfcd
-        with:
-          allowUpdates: true
-          draft: ${{ github.event_name == 'pull_request' }}
-          tag: ${{ steps.tag.outputs.value }}
-          artifacts: "target/release/rfd-api"
-          generateReleaseNotes: true
+      - name: Upload Release Artifact
+        run: |
+          gh release upload --clobber "${{ steps.tag.outputs.value }}" "target/release/rfd-api"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build Release Binary
         run: |
-          cargo build --release --package rfd-api --no-default-features
+          cargo build --release --package rfd-api
 
       - name: Upload Release Artifact
         run: |

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -14,9 +14,11 @@ concurrency:
 jobs:
   release:
     if: >-
-      github.event_name == 'push' ||
-      github.event.label.name == 'release-test' ||
-      contains(github.event.pull_request.labels.*.name, 'release-test')
+      github.repository_owner == 'oxidecomputer' && (
+        github.event_name == 'push' ||
+        github.event.label.name == 'release-test' ||
+        contains(github.event.pull_request.labels.*.name, 'release-test')
+      )
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release CLI
 on:
   push:
     tags:
-      - "**[0-9]+.[0-9]+.[0-9]+*"
+      - "v*.*.*"
   pull_request:
     types: [labeled, synchronize]
 
@@ -63,3 +63,4 @@ jobs:
           draft: ${{ github.event_name == 'pull_request' }}
           tag: ${{ steps.tag.outputs.value }}
           artifacts: "target/release/${{ matrix.artifact }}"
+          prerelease: ${{ contains(steps.tag.outputs.value, '-pre') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         github.event.label.name == 'release-test' ||
         contains(github.event.pull_request.labels.*.name, 'release-test')
       )
+
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release CLI
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     types: [labeled, synchronize]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,11 @@ on:
 jobs:
   release:
     if: >-
-      github.event_name == 'push' ||
-      github.event.label.name == 'release-test' ||
-      contains(github.event.pull_request.labels.*.name, 'release-test')
+      github.repository_owner == 'oxidecomputer' && (
+        github.event_name == 'push' ||
+        github.event.label.name == 'release-test' ||
+        contains(github.event.pull_request.labels.*.name, 'release-test')
+      )
     strategy:
       matrix:
         include:


### PR DESCRIPTION
- release-api.yml: Create release first
- release.yml: Fix for setting prereleases
- release.yml: Only run if org == oxidecomputer
- better tag globbing for both