### PR TITLE
Update dependencies 2026-05-12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.8"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78df0e4e8c596662edb07fbfbb7f23769cca35049827df5f909084d956b6aeaf"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4507,7 +4507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap = { version = "4.6.1", features = ["derive", "string", "env"] }
 config = { version = "0.15.22", features = ["toml"] }
 cookie = { version = "0.18.1" }
 crc32c = "0.6.8"
-diesel = { version = "2.3.8", features = ["postgres"] }
+diesel = { version = "2.3.9", features = ["postgres"] }
 diesel_migrations = { version = "2.3.2" }
 dirs = "6.0.0"
 dropshot = "0.16"

--- a/rfd-model/Cargo.toml
+++ b/rfd-model/Cargo.toml
@@ -27,5 +27,5 @@ uuid = { workspace = true, features = ["v4", "serde"]  }
 v-model = { workspace = true }
 
 [dev-dependencies]
-diesel_migrations = { version = "2.3.1", features = ["postgres"] }
+diesel_migrations = { workspace = true, features = ["postgres"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
Diesel, diesel_migrations, quinn-proto

- Closes: https://github.com/oxidecomputer/rfd-api/pull/428
- Closes: https://github.com/oxidecomputer/rfd-api/pull/443
- Closes: https://github.com/oxidecomputer/rfd-api/pull/444
