### PR TITLE
Update dropshot, v_api, etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -894,7 +894,7 @@ dependencies = [
  "rustls-pemfile",
  "schemars 0.8.22",
  "scopeguard",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -955,7 +955,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_tokenstream",
  "syn",
@@ -1061,12 +1061,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1879,7 +1873,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
+ "rustc_version",
  "simd_cesu8",
  "syn",
 ]
@@ -2280,15 +2274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "newtype_derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
-dependencies = [
- "rustc_version 0.1.7",
-]
-
-[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,19 +2639,6 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3374,7 +3346,7 @@ dependencies = [
  "rustls 0.23.36",
  "schemars 0.8.22",
  "secrecy",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3609,20 +3581,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-dependencies = [
- "semver 0.1.20",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -3900,12 +3863,6 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-
-[[package]]
-name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
@@ -4157,7 +4114,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
  "simdutf8",
 ]
 
@@ -4302,27 +4259,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "steno"
-version = "0.4.2-dev"
-source = "git+https://github.com/oxidecomputer/steno#5b0d1be32fb3e3047ff4e4f972b59dc52f9c89ba"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "futures",
- "lazy_static",
- "newtype_derive",
- "petgraph",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "slog",
- "thiserror 2.0.18",
- "tokio",
- "uuid",
-]
 
 [[package]]
 name = "strsim"
@@ -4755,7 +4691,7 @@ dependencies = [
  "home",
  "once_cell",
  "regex",
- "semver 1.0.28",
+ "semver",
  "walkdir",
 ]
 
@@ -4952,7 +4888,7 @@ dependencies = [
  "quote",
  "regress",
  "schemars 0.8.22",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "syn",
@@ -4969,7 +4905,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars 0.8.22",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "serde_tokenstream",
@@ -5102,8 +5038,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha2 0.11.0",
- "slog",
- "steno",
  "tap",
  "thiserror 2.0.18",
  "tokio",
@@ -5161,7 +5095,6 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "steno",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -5368,7 +5301,7 @@ dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -5764,7 +5697,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.14.0",
  "log",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5787,7 +5720,7 @@ dependencies = [
  "progenitor",
  "regex",
  "rustfmt-wrapper",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "similar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,13 +97,26 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 [[package]]
 name = "async-bb8-diesel"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel#f049570ff89080b2385c637af4c0e614b0a124a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433a78c27b116e74d1c773b4b2e76a83cde6dc1e7ca2b65345dcf597d34f16b4"
 dependencies = [
  "async-trait",
  "bb8",
  "diesel",
  "futures",
  "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -179,12 +198,6 @@ dependencies = [
  "dunce",
  "fs_extra",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -414,6 +427,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "config"
 version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,7 +573,16 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -566,18 +605,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-common"
@@ -605,33 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -776,14 +776,13 @@ dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.6",
- "subtle",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -866,10 +865,11 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dropshot"
-version = "0.16.7"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69fd85c8dfc67252d02f260595f6b62b5abceb1b88b4b9722369d27936e5fa4"
+checksum = "409eb76c7ea1623d270393248ff55ec436841fcd724c2e1c9de294291edd35f5"
 dependencies = [
+ "async-compression",
  "async-stream",
  "async-trait",
  "base64",
@@ -894,7 +894,7 @@ dependencies = [
  "rustls-pemfile",
  "schemars 0.8.22",
  "scopeguard",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -908,7 +908,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.25.0",
- "toml 0.9.12+spec-1.1.0",
+ "tokio-util",
+ "toml 1.1.2+spec-1.1.0",
  "uuid",
  "version_check",
  "waitgroup",
@@ -916,8 +917,8 @@ dependencies = [
 
 [[package]]
 name = "dropshot-authorization-header"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/v-api#1ba9ce83fa58a543c23e7da80590008c3e3c33bb"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "async-trait",
  "base64",
@@ -927,34 +928,34 @@ dependencies = [
 
 [[package]]
 name = "dropshot-verified-body"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dropshot-verified-body#6f709859b2f7bb2aed26a8eb784319b9ac587a9f"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/dropshot-verified-body?rev=0b124eeb0f52db783a44d395a41425a1f9b709b7#0b124eeb0f52db783a44d395a41425a1f9b709b7"
 dependencies = [
  "async-trait",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dropshot",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http 1.4.0",
  "hyper",
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "dropshot_endpoint"
-version = "0.16.7"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d106478e4a4782556981d028a667f41c4845cdaa6e2d3a9f58c5d15e725401"
+checksum = "906c3adfd4472030607130ed763e9af1b85f7e18832dd22998379d42ff81c28d"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_tokenstream",
  "syn",
@@ -987,20 +988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ecow"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,57 +997,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1115,26 +1057,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1277,7 +1219,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1429,17 +1370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,30 +1454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1648,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1663,7 +1575,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1968,7 +1879,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "simd_cesu8",
  "syn",
 ]
@@ -2046,18 +1957,11 @@ checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac 0.12.1",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.5",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -2185,7 +2089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2291,6 +2195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2277,15 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "newtype_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
+dependencies = [
+ "rustc_version 0.1.7",
 ]
 
 [[package]]
@@ -2481,6 +2404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2-reqwest"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
+dependencies = [
+ "oauth2",
+ "reqwest 0.13.3",
+]
+
+[[package]]
 name = "octorust"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,30 +2497,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2748,6 +2657,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,15 +2783,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -3278,7 +3191,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3292,6 +3205,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.4.0",
  "http-body",
@@ -3313,12 +3227,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3415,16 +3331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "rfd-api"
 version = "0.14.5"
 dependencies = [
@@ -3468,7 +3374,7 @@ dependencies = [
  "rustls 0.23.36",
  "schemars 0.8.22",
  "secrecy",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3593,7 +3499,7 @@ dependencies = [
  "google-drive3",
  "google-storage1",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "http 1.4.0",
  "md-5",
  "meilisearch-sdk",
@@ -3703,11 +3609,20 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+dependencies = [
+ "semver 0.1.20",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -3951,20 +3866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,6 +3897,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "semver"
@@ -4200,7 +4107,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4239,12 +4146,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
  "simdutf8",
 ]
 
@@ -4389,6 +4302,27 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "steno"
+version = "0.4.2-dev"
+source = "git+https://github.com/oxidecomputer/steno#5b0d1be32fb3e3047ff4e4f972b59dc52f9c89ba"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "lazy_static",
+ "newtype_derive",
+ "petgraph",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "strsim"
@@ -4728,12 +4662,10 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "toml_writer",
  "winnow 0.7.14",
 ]
 
@@ -4823,7 +4755,7 @@ dependencies = [
  "home",
  "once_cell",
  "regex",
- "semver",
+ "semver 1.0.28",
  "walkdir",
 ]
 
@@ -5020,7 +4952,7 @@ dependencies = [
  "quote",
  "regress",
  "schemars 0.8.22",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "syn",
@@ -5037,7 +4969,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars 0.8.22",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serde_tokenstream",
@@ -5138,15 +5070,15 @@ dependencies = [
 
 [[package]]
 name = "v-api"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/v-api#1ba9ce83fa58a543c23e7da80590008c3e3c33bb"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64",
  "chrono",
  "cookie",
  "crc32c",
- "diesel",
  "dropshot",
  "dropshot-authorization-header",
  "futures",
@@ -5158,24 +5090,27 @@ dependencies = [
  "jsonwebtoken 10.3.0",
  "newtype-uuid",
  "oauth2",
+ "oauth2-reqwest",
  "partial-struct",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "reqwest 0.12.28",
+ "percent-encoding",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
  "rsa",
  "schemars 0.8.22",
  "secrecy",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2 0.10.9",
+ "sha2 0.11.0",
+ "slog",
+ "steno",
  "tap",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
  "uuid",
+ "v-api-param",
  "v-api-permission-derive",
  "v-model",
  "yup-oauth2",
@@ -5183,17 +5118,27 @@ dependencies = [
 
 [[package]]
 name = "v-api-installer"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/v-api#1ba9ce83fa58a543c23e7da80590008c3e3c33bb"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "diesel",
  "diesel_migrations",
 ]
 
 [[package]]
+name = "v-api-param"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+dependencies = [
+ "secrecy",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "v-api-permission-derive"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/v-api#1ba9ce83fa58a543c23e7da80590008c3e3c33bb"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5203,8 +5148,8 @@ dependencies = [
 
 [[package]]
 name = "v-model"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/v-api#1ba9ce83fa58a543c23e7da80590008c3e3c33bb"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "async-bb8-diesel",
  "async-trait",
@@ -5216,6 +5161,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "steno",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -5386,6 +5332,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,7 +5368,7 @@ dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5805,7 +5764,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.14.0",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5828,7 +5787,7 @@ dependencies = [
  "progenitor",
  "regex",
  "rustfmt-wrapper",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "similar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ tracing-slog = { git = "https://github.com/oxidecomputer/tracing-slog", default-
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
 valuable = "0.1.1"
-v-api = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+v-api = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623", default-features = false }
 v-api-installer = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
 v-model = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
 v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2024"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", version = "0.3" }
+async-bb8-diesel = "0.3.0"
 async-trait = "0.1.89"
 base64 = "0.22"
 bb8 = "0.9"
@@ -32,16 +32,16 @@ crc32c = "0.6.8"
 diesel = { version = "2.3.9", features = ["postgres"] }
 diesel_migrations = { version = "2.3.2" }
 dirs = "6.0.0"
-dropshot = "0.16"
-dropshot-authorization-header = { git = "https://github.com/oxidecomputer/v-api" }
-dropshot-verified-body = { git = "https://github.com/oxidecomputer/dropshot-verified-body" }
+dropshot = "0.17"
+dropshot-authorization-header = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+dropshot-verified-body = { git = "https://github.com/oxidecomputer/dropshot-verified-body", rev = "0b124eeb0f52db783a44d395a41425a1f9b709b7" }
 futures = "0.3.32"
 google-drive3 = "7.0.0"
 google-storage1 = "7.0.0"
 hex = "0.4.3"
 hmac = "0.13.0"
 http = "1.4.0"
-hyper = "1.8.1"
+hyper = "1.9.0"
 itertools = "0.14.0"
 jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }
 meilisearch-sdk = "0.33.0"
@@ -92,10 +92,10 @@ tracing-slog = { git = "https://github.com/oxidecomputer/tracing-slog", default-
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
 valuable = "0.1.1"
-v-api = { git = "https://github.com/oxidecomputer/v-api" }
-v-api-installer = { git = "https://github.com/oxidecomputer/v-api" }
-v-model = { git = "https://github.com/oxidecomputer/v-api" }
-v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api" }
+v-api = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+v-api-installer = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+v-model = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
 yup-oauth2 = { version = "12.1.2" }
 
 # Config for 'cargo dist'

--- a/rfd-api/src/context.rs
+++ b/rfd-api/src/context.rs
@@ -952,13 +952,14 @@ pub(crate) mod test_mocks {
     use v_api::{
         config::{AsymmetricKey, JwtConfig},
         endpoints::login::oauth::{google::GoogleOAuthProvider, OAuthProviderName},
-        VContext,
+        VContextBuilder,
     };
     use v_model::storage::postgres::PostgresStore;
 
     use crate::config::{
         ContentConfig, GitHubAuthConfig, GitHubConfig, SearchConfig, ServicesConfig,
     };
+    use crate::permissions::RfdPermission;
 
     use super::RfdContext;
 
@@ -989,23 +990,27 @@ pub(crate) mod test_mocks {
                     .as_bytes()
                     .to_vec(),
             )
-            .unwrap(),
+            .unwrap()
+            .into(),
         };
         let verifier = AsymmetricKey::LocalVerifier {
             kid: hex::encode(kid),
-            public: pub_key.to_public_key_pem(LineEnding::LF).unwrap(),
+            public: pub_key.to_public_key_pem(LineEnding::LF).unwrap().into(),
         };
 
-        let mut v_context = VContext::new(
-            String::new(),
-            Arc::new(PostgresStore::new("").await.unwrap()),
-            JwtConfig {
-                default_expiration: 0,
-            },
-            vec![signer, verifier],
-        )
-        .await
-        .unwrap();
+        let mut v_context = VContextBuilder::<RfdPermission>::new()
+            .with_public_url(String::new())
+            .with_storage(Arc::new(PostgresStore::new("").await.unwrap()))
+            .with_jwt_expiration(
+                JwtConfig {
+                    default_expiration: 0,
+                }
+                .default_expiration,
+            )
+            .with_keys(vec![signer, verifier])
+            .build()
+            .await
+            .unwrap();
         v_context.insert_oauth_provider(
             OAuthProviderName::Google,
             Box::new(move || {

--- a/rfd-api/src/main.rs
+++ b/rfd-api/src/main.rs
@@ -7,6 +7,7 @@ use minijinja::Environment;
 use server::{server, ServerConfig};
 use std::{
     net::{SocketAddr, SocketAddrV4},
+    path::Path,
     sync::Arc,
 };
 use tap::TapFallible;
@@ -16,7 +17,7 @@ use v_api::{
     endpoints::login::oauth::{
         github::GitHubOAuthProvider, google::GoogleOAuthProvider, OAuthProviderName,
     },
-    ApiContext, MagicLinkTarget, VContext,
+    ApiContext, MagicLinkTarget, VContextBuilder,
 };
 use v_model::{schema_ext::MagicLinkMedium, storage::postgres::PostgresStore as VApiPostgresStore};
 
@@ -52,8 +53,13 @@ async fn main() -> anyhow::Result<()> {
     let mut args = std::env::args();
     let _ = args.next();
     let config_path = args.next();
+    let param_path = config_path
+        .as_deref()
+        .and_then(|path| Path::new(path).parent())
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(|path| path.to_path_buf());
 
-    let config = AppConfig::new(config_path.map(|path| vec![path]))?;
+    let mut config = AppConfig::new(config_path.clone().map(|path| vec![path]))?;
 
     let (writer, _guard) = if let Some(log_directory) = config.log_directory {
         let file_appender = tracing_appender::rolling::daily(log_directory, "rfd-api.log");
@@ -75,29 +81,34 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Initialized logger");
 
-    let mut v_ctx = VContext::new(
-        config.public_url.clone(),
-        Arc::new(
-            VApiPostgresStore::new(&config.database_url)
-                .await
-                .tap_err(|err| {
-                    tracing::error!(?err, "Failed to establish initial database connection");
-                })?,
-        ),
-        config.jwt,
-        config.keys,
-    )
-    .await?;
+    let storage = Arc::new(
+        VApiPostgresStore::new(&config.database_url)
+            .await
+            .tap_err(|err| {
+                tracing::error!(?err, "Failed to establish initial database connection");
+            })?,
+    );
+    let mut v_ctx_builder = VContextBuilder::<RfdPermission>::new()
+        .with_public_url(config.public_url.clone())
+        .with_storage(storage.clone())
+        .with_jwt_expiration(config.jwt.default_expiration)
+        .with_keys(std::mem::take(&mut config.keys));
+    if let Some(param_path) = param_path.clone() {
+        v_ctx_builder = v_ctx_builder.with_param_path(param_path);
+    }
+    let mut v_ctx = v_ctx_builder.build().await?;
 
     if let Some(github) = config.authn.oauth.github {
+        let device_client_secret = github.device.client_secret.resolve(param_path.clone())?;
+        let web_client_secret = github.web.client_secret.resolve(param_path.clone())?;
         v_ctx.insert_oauth_provider(
             OAuthProviderName::GitHub,
             Box::new(move || {
                 Box::new(GitHubOAuthProvider::new(
                     github.device.client_id.clone(),
-                    github.device.client_secret.clone(),
+                    device_client_secret.clone(),
                     github.web.client_id.clone(),
-                    github.web.client_secret.clone(),
+                    web_client_secret.clone(),
                     None,
                 ))
             }),
@@ -107,14 +118,16 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if let Some(google) = config.authn.oauth.google {
+        let device_client_secret = google.device.client_secret.resolve(param_path.clone())?;
+        let web_client_secret = google.web.client_secret.resolve(param_path.clone())?;
         v_ctx.insert_oauth_provider(
             OAuthProviderName::Google,
             Box::new(move || {
                 Box::new(GoogleOAuthProvider::new(
                     google.device.client_id.clone(),
-                    google.device.client_secret.clone(),
+                    device_client_secret.clone(),
                     google.web.client_id.clone(),
-                    google.web.client_secret.clone(),
+                    web_client_secret.clone(),
                     None,
                 ))
             }),
@@ -163,13 +176,7 @@ async fn main() -> anyhow::Result<()> {
 
     let context = RfdContext::new(
         config.public_url,
-        Arc::new(
-            VApiPostgresStore::new(&config.database_url)
-                .await
-                .tap_err(|err| {
-                    tracing::error!(?err, "Failed to establish initial database connection");
-                })?,
-        ),
+        storage,
         config.search,
         config.content,
         config.services,


### PR DESCRIPTION
- async-bb8-diesel: git 0.3 to crates 0.3.0
- dropshot: 0.16 to 0.17
- v-api: 0.1.0 to 0.3.1 (git)
- dropshot-verified-body: 0.1.0 to 0.2.0 (git)
- hyper: 1.8.1 to 1.9.0
