### PR TITLE
Pin v-api via tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "dropshot-authorization-header"
 version = "0.3.1"
-source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.3.1#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "async-trait",
  "base64",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "v-api"
 version = "0.3.1"
-source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.3.1#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5053,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "v-api-installer"
 version = "0.3.1"
-source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.3.1#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "v-api-param"
 version = "0.3.1"
-source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.3.1#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "secrecy",
  "serde",
@@ -5072,7 +5072,7 @@ dependencies = [
 [[package]]
 name = "v-api-permission-derive"
 version = "0.3.1"
-source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.3.1#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5083,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "v-model"
 version = "0.3.1"
-source = "git+https://github.com/oxidecomputer/v-api?rev=d3fff6f7e539a9435e8dcbb07b54e937237ff623#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.3.1#d3fff6f7e539a9435e8dcbb07b54e937237ff623"
 dependencies = [
  "async-bb8-diesel",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ diesel = { version = "2.3.9", features = ["postgres"] }
 diesel_migrations = { version = "2.3.2" }
 dirs = "6.0.0"
 dropshot = "0.17"
-dropshot-authorization-header = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+dropshot-authorization-header = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.3.1" }
 dropshot-verified-body = { git = "https://github.com/oxidecomputer/dropshot-verified-body", rev = "0b124eeb0f52db783a44d395a41425a1f9b709b7" }
 futures = "0.3.32"
 google-drive3 = "7.0.0"
@@ -92,10 +92,10 @@ tracing-slog = { git = "https://github.com/oxidecomputer/tracing-slog", default-
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
 valuable = "0.1.1"
-v-api = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623", default-features = false }
-v-api-installer = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
-v-model = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
-v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", rev = "d3fff6f7e539a9435e8dcbb07b54e937237ff623" }
+v-api = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.3.1", default-features = false }
+v-api-installer = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.3.1" }
+v-model = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.3.1" }
+v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.3.1" }
 yup-oauth2 = { version = "12.1.2" }
 
 # Config for 'cargo dist'


### PR DESCRIPTION
Specify the v-api dependency via `tag` instead of `rev`.
Cargo.lock still pins to the commit.
This is a no-op, but improves visibility when looking at Cargo.toml files.