### PR TITLE
rfd-processor: Reduce log verbosity

### DIFF
--- a/rfd-github/src/lib.rs
+++ b/rfd-github/src/lib.rs
@@ -269,7 +269,7 @@ impl GitHubRfdRepo {
             .await?
             .body;
 
-        tracing::info!(?rfd_files, "Fetched repo files");
+        tracing::info!(count = ?rfd_files.len(), "Fetched repo files");
 
         // Each RFD should exist at a path that looks like rfd/{number}/README.adoc
         for entry in rfd_files {

--- a/rfd-processor/src/scanner.rs
+++ b/rfd-processor/src/scanner.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use rfd_github::{GitHubError, GitHubRfdUpdate};
 use rfd_model::{storage::JobStore, NewJob};
 use std::sync::Arc;
@@ -37,10 +36,7 @@ pub async fn scanner(ctx: Arc<Context>) -> Result<(), ScannerError> {
                     Ok(job) => tracing::trace!(?job.id, "Added job to the queue"),
                     Err(err) => {
                         match err {
-                            StoreError::Db(DieselError::DatabaseError(
-                                DatabaseErrorKind::UniqueViolation,
-                                _,
-                            )) => {
+                            StoreError::Conflict => {
                                 // Nothing to do here, we expect uniqueness conflicts. It is expected
                                 // that the scanner picks ups redundant jobs for RFDs that have not
                                 // changed since the last scan


### PR DESCRIPTION
Reduce log volumes by 65% (76MB/day -> 28MB/day)
Reduce log line count by 68% (98.5k/day -> 31k/day)

- Change "Fetched repo files": Log `rfd_files.len` instead of entire `rfd_files` structure (96 lines day; 20MB/76MB)
  - 0.1% of log lines; 25% of log volume
  - introduced in https://github.com/oxidecomputer/rfd-api/commit/92687cc2456875c412374b5b91e15a16806e1dff (2024-04-12)
- Catch `StoreError::Conflict` result from V-API (67.5k / 98.5k lines; 28MB/76MB)
  - 69% of log lines; 37% of log volume
  - v-api change: https://github.com/oxidecomputer/v-api/commit/8c805ea7775c4f5154acb89a8d4de91565d16a99 (2025-04-25)
  - rfd-api switch: https://github.com/oxidecomputer/rfd-api/commit/21b13a67312e3393bdf2653668945d580b5f30e2 (2025-06-10)