### PR TITLE
cargo xtask bump improvements

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -102,7 +102,7 @@ fn bump_package_versions(place: &VersionPlace) -> Result<(), String> {
         return Err("cargo check failed".to_string());
     }
 
-    Ok(())
+    generate(false, false)
 }
 
 trait Bump {


### PR DESCRIPTION
- run `cargo xtask generate` on `cargo xtask bump`
- Also ensures trailing newline on package.json (because generate runs dprint)