### PR TITLE
Bump Rust to v1.95.0

### DIFF
--- a/rfd-api/src/context.rs
+++ b/rfd-api/src/context.rs
@@ -473,7 +473,7 @@ impl RfdContext {
             .collect::<Vec<_>>();
 
         // Finally sort the RFD list by RFD number
-        rfd_list.sort_by(|a, b| b.rfd_number.cmp(&a.rfd_number));
+        rfd_list.sort_by_key(|b| std::cmp::Reverse(b.rfd_number));
 
         Ok(rfd_list)
     }
@@ -927,7 +927,7 @@ impl RfdContext {
         });
 
         // Finally sort the jobs list by create time
-        jobs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        jobs.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         Ok(jobs)
     }

--- a/rfd-github/src/lib.rs
+++ b/rfd-github/src/lib.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// TODO(peter): Remove this when we replace octorust
+#![allow(clippy::result_large_err)]
+
 use std::{
     borrow::Cow,
     collections::HashMap,

--- a/rfd-processor/src/main.rs
+++ b/rfd-processor/src/main.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// TODO(peter): Remove this when we replace octorust
+#![allow(clippy::result_large_err)]
+
 use clap::Parser;
 use config::{Config, ConfigError, Environment, File};
 use processor::{processor, JobError};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Bump to v1.95.0 to match other v-api services (turnstile, etc).
Fix new clippy compliants (mostly octorust).

Current cargo-shear didn't work with v1.93.1
See: https://github.com/oxidecomputer/rfd-api/pull/490