### PR TITLE
Make permissions implies explicit

### DIFF
--- a/rfd-api/src/permissions.rs
+++ b/rfd-api/src/permissions.rs
@@ -28,7 +28,12 @@ pub enum RfdPermission {
         scope(to = "rfd:content:r", from = "rfd:content:r")
     )]
     GetRfdsAssigned,
-    #[v_api(scope(to = "rfd:content:r", from = "rfd:content:r"))]
+    #[v_api(
+        implies(variant = GetRfd),
+        implies(variant = GetRfds),
+        implies(variant = GetRfdsAssigned),
+        scope(to = "rfd:content:r", from = "rfd:content:r")
+    )]
     GetRfdsAll,
     #[v_api(scope(to = "rfd:content:w", from = "rfd:content:w"))]
     CreateRfd,
@@ -48,7 +53,12 @@ pub enum RfdPermission {
         scope(to = "rfd:content:w", from = "rfd:content:w")
     )]
     UpdateRfdsAssigned,
-    #[v_api(scope(to = "rfd:content:w", from = "rfd:content:w"))]
+    #[v_api(
+        implies(variant = UpdateRfd),
+        implies(variant = UpdateRfds),
+        implies(variant = UpdateRfdsAssigned),
+        scope(to = "rfd:content:w", from = "rfd:content:w")
+    )]
     UpdateRfdsAll,
     #[v_api(
         contract(kind = append, variant = ManageRfdsVisibility),
@@ -66,7 +76,12 @@ pub enum RfdPermission {
         scope(to = "rfd:visibility:w", from = "rfd:visibility:w")
     )]
     ManageRfdsVisibilityAssigned,
-    #[v_api(scope(to = "rfd:visibility:w", from = "rfd:visibility:w"))]
+    #[v_api(
+        implies(variant = ManageRfdVisibility),
+        implies(variant = ManageRfdsVisibility),
+        implies(variant = ManageRfdsVisibilityAssigned),
+        scope(to = "rfd:visibility:w", from = "rfd:visibility:w")
+    )]
     ManageRfdsVisibilityAll,
     #[v_api(
         contract(kind = append, variant = GetDiscussions),
@@ -84,8 +99,113 @@ pub enum RfdPermission {
         scope(to = "rfd:discussion:r", from = "rfd:discussion:r")
     )]
     GetDiscussionsAssigned,
-    #[v_api(scope(to = "rfd:discussion:r", from = "rfd:discussion:r"))]
+    #[v_api(
+        implies(variant = GetDiscussion),
+        implies(variant = GetDiscussions),
+        implies(variant = GetDiscussionsAssigned),
+        scope(to = "rfd:discussion:r", from = "rfd:discussion:r")
+    )]
     GetDiscussionsAll,
     #[v_api(scope(to = "search", from = "search"))]
     SearchRfds,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use strum::IntoEnumIterator;
+    use v_model::permissions::{PermissionStorage, Permissions};
+
+    use super::RfdPermission;
+
+    #[test]
+    fn all_variants_imply_granular_variants() {
+        assert!(RfdPermission::implies(
+            &RfdPermission::GetRfdsAll,
+            &RfdPermission::GetRfd(591)
+        ));
+        assert!(RfdPermission::implies(
+            &RfdPermission::GetRfdsAll,
+            &RfdPermission::GetRfds(BTreeSet::from([1, 2, 3]))
+        ));
+        assert!(RfdPermission::implies(
+            &RfdPermission::GetRfdsAll,
+            &RfdPermission::GetRfdsAssigned
+        ));
+
+        assert!(RfdPermission::implies(
+            &RfdPermission::UpdateRfdsAll,
+            &RfdPermission::UpdateRfd(591)
+        ));
+        assert!(RfdPermission::implies(
+            &RfdPermission::ManageRfdsVisibilityAll,
+            &RfdPermission::ManageRfdVisibility(591)
+        ));
+        assert!(RfdPermission::implies(
+            &RfdPermission::GetDiscussionsAll,
+            &RfdPermission::GetDiscussion(591)
+        ));
+    }
+
+    #[test]
+    fn granular_variants_do_not_imply_all_variants() {
+        assert!(!RfdPermission::implies(
+            &RfdPermission::GetRfd(591),
+            &RfdPermission::GetRfdsAll
+        ));
+        assert!(!RfdPermission::implies(
+            &RfdPermission::GetRfds(BTreeSet::from([591])),
+            &RfdPermission::GetRfdsAll
+        ));
+    }
+
+    #[test]
+    fn all_variants_do_not_imply_across_families() {
+        assert!(!RfdPermission::implies(
+            &RfdPermission::GetRfdsAll,
+            &RfdPermission::UpdateRfd(591)
+        ));
+        assert!(!RfdPermission::implies(
+            &RfdPermission::GetRfdsAll,
+            &RfdPermission::GetDiscussion(591)
+        ));
+    }
+
+    #[test]
+    fn set_variants_imply_contained_elements() {
+        assert!(RfdPermission::implies(
+            &RfdPermission::GetRfds(BTreeSet::from([1, 591])),
+            &RfdPermission::GetRfd(591)
+        ));
+        assert!(!RfdPermission::implies(
+            &RfdPermission::GetRfds(BTreeSet::from([1])),
+            &RfdPermission::GetRfd(591)
+        ));
+        assert!(RfdPermission::implies(
+            &RfdPermission::GetRfds(BTreeSet::from([1, 2, 591])),
+            &RfdPermission::GetRfds(BTreeSet::from([1, 591]))
+        ));
+    }
+
+    // Regression test: at login v-api re-applies mapped groups, and
+    // add_api_user_to_group requires the builtin registration caller to pass
+    // can_grant_all(group.permissions). The registration caller is built from
+    // RfdPermission::iter() (see main.rs), which holds the *All variants. It
+    // must be able to grant groups composed of granular per-RFD permissions,
+    // otherwise every login matching such a mapper fails with a 403.
+    #[test]
+    fn registration_permissions_can_grant_granular_group_permissions() {
+        let registration: Permissions<RfdPermission> =
+            RfdPermission::iter().collect::<Vec<_>>().into();
+
+        let customer_group: Permissions<RfdPermission> = vec![
+            RfdPermission::GetRfd(216),
+            RfdPermission::GetRfd(591),
+            RfdPermission::GetRfds(BTreeSet::from([7, 343, 584])),
+        ]
+        .into();
+
+        assert!(registration.can_grant_all(&customer_group));
+    }
 }


### PR DESCRIPTION
- See: https://github.com/oxidecomputer/rfd-api/issues/492

Explicitly specify that:
- `GetRfdsAll` implies 
  - `GetRfd`
  - `GetRfds`
  - `GetRfdsAssigned`
- `UpdateRfdsAll` implies
  - `UpdateRfd`
  - `UpdateRfds`
  - `UpdateRfdsAssigned`
- `ManageRfdsVisibilityAll` implies 
  - `ManageRfdVisibility`
  - `ManageRfdsVisibility`
  - `ManageRfdsVisibilityAssigned`
- `GetDiscussionsAll` implies
  - `GetDiscussion`
  - `GetDiscussions
  - `GetDiscussionsAssigned`

So mappers with `GetRfd` can be invoked when the process has `GetRfdsAll`