### PR TITLE
Update v-api to 0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -393,14 +393,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -679,7 +679,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -692,7 +692,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -703,7 +703,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -714,7 +714,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -791,7 +791,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -886,7 +886,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -964,8 +964,8 @@ dependencies = [
 
 [[package]]
 name = "dropshot-authorization-header"
-version = "0.4.7"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.7#e819eddd0cdd229e39eb2ad4a4eab00920a43e04"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
 dependencies = [
  "async-trait",
  "base64",
@@ -1005,7 +1005,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_tokenstream",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1019,7 +1019,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1211,7 +1211,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1883,7 +1883,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1902,7 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2076,7 +2076,7 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2235,7 +2235,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2559,7 +2559,7 @@ source = "git+https://github.com/oxidecomputer/partial-struct#4bebbcfcbc3f0c4b7d
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2629,7 +2629,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2798,7 +2798,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
  "thiserror 2.0.18",
  "typify",
  "unicode-ident",
@@ -2819,7 +2819,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3083,7 +3083,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3756,7 +3756,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3853,7 +3853,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3864,7 +3864,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3918,7 +3918,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3962,7 +3962,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4225,7 +4225,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4236,7 +4236,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4257,7 +4257,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4284,6 +4284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4300,7 +4311,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4390,7 +4401,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4401,7 +4412,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4504,7 +4515,7 @@ checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4698,7 +4709,7 @@ dependencies = [
  "http 1.4.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "tracing",
 ]
 
@@ -4734,7 +4745,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4841,7 +4852,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -4859,7 +4870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn",
+ "syn 2.0.119",
  "typify-impl",
 ]
 
@@ -4945,8 +4956,8 @@ dependencies = [
 
 [[package]]
 name = "v-api"
-version = "0.4.7"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.7#e819eddd0cdd229e39eb2ad4a4eab00920a43e04"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4990,8 +5001,8 @@ dependencies = [
 
 [[package]]
 name = "v-api-param"
-version = "0.4.7"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.7#e819eddd0cdd229e39eb2ad4a4eab00920a43e04"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
 dependencies = [
  "secrecy",
  "serde",
@@ -5000,19 +5011,19 @@ dependencies = [
 
 [[package]]
 name = "v-api-permission-derive"
-version = "0.4.7"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.7#e819eddd0cdd229e39eb2ad4a4eab00920a43e04"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "v-cli-sdk"
-version = "0.4.7"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.7#e819eddd0cdd229e39eb2ad4a4eab00920a43e04"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
 dependencies = [
  "anyhow",
  "clap",
@@ -5034,8 +5045,8 @@ dependencies = [
 
 [[package]]
 name = "v-model"
-version = "0.4.7"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.7#e819eddd0cdd229e39eb2ad4a4eab00920a43e04"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
 dependencies = [
  "async-bb8-diesel",
  "async-trait",
@@ -5157,7 +5168,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -5301,7 +5312,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5312,7 +5323,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5517,7 +5528,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5563,7 +5574,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5583,7 +5594,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5604,7 +5615,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5637,7 +5648,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-bb8-diesel = "0.3.0"
 async-trait = "0.1.89"
 base64 = "0.22"
 chrono = "0.4.44"
-clap = { version = "4.6.1", features = ["derive", "string", "env"] }
+clap = { version = "4.6.4", features = ["derive", "string", "env"] }
 config = { version = "0.15.25", features = ["toml"] }
 diesel = { version = "2.3.9", features = ["postgres"] }
 diesel_migrations = { version = "2.3.2" }
@@ -76,10 +76,10 @@ tracing-appender = "0.2.5"
 tracing-slog = { git = "https://github.com/oxidecomputer/tracing-slog", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
-v-api = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.7", default-features = false }
-v-cli-sdk = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.7" }
-v-model = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.7" }
-v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.7" }
+v-api = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9", default-features = false }
+v-cli-sdk = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9" }
+v-model = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9" }
+v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9" }
 yup-oauth2 = { version = "12.1.2", default-features = false, features = ["hyper-rustls", "service-account", "aws-lc-rs"] }
 
 # Config for 'cargo dist'


### PR DESCRIPTION
This picks up the improved logging from:
- https://github.com/oxidecomputer/v-api/pull/511

As well as some random rust crate bumps.
Release notes: https://github.com/oxidecomputer/v-api/releases/tag/v0.4.9