### PR TITLE
rfd-processor: Survive transient github errors

### DIFF
--- a/rfd-processor/src/processor.rs
+++ b/rfd-processor/src/processor.rs
@@ -39,14 +39,24 @@ pub async fn processor(ctx: Arc<Context>) -> Result<(), JobError> {
 
     loop {
         if ctx.processor.enabled {
-            let jobs = JobStore::list(
+            // Errors fetching the job list (i.e. transient database failures) must not take down
+            // the processor. Skip this batch and try again on the next tick
+            let jobs = match JobStore::list(
                 &ctx.db.storage,
                 vec![JobFilter::default()
                     .processed(Some(false))
                     .started(Some(false))],
                 &pagination,
             )
-            .await?;
+            .await
+            {
+                Ok(jobs) => jobs,
+                Err(err) => {
+                    tracing::error!(?err, "Failed to fetch job batch");
+                    interval.tick().await;
+                    continue;
+                }
+            };
 
             tracing::info!(jobs = ?jobs.iter().map(|job| job.id).collect::<Vec<_>>(), "Spawning jobs");
 

--- a/rfd-processor/src/processor.rs
+++ b/rfd-processor/src/processor.rs
@@ -39,24 +39,14 @@ pub async fn processor(ctx: Arc<Context>) -> Result<(), JobError> {
 
     loop {
         if ctx.processor.enabled {
-            // Errors fetching the job list (i.e. transient database failures) must not take down
-            // the processor. Skip this batch and try again on the next tick
-            let jobs = match JobStore::list(
+            let jobs = JobStore::list(
                 &ctx.db.storage,
                 vec![JobFilter::default()
                     .processed(Some(false))
                     .started(Some(false))],
                 &pagination,
             )
-            .await
-            {
-                Ok(jobs) => jobs,
-                Err(err) => {
-                    tracing::error!(?err, "Failed to fetch job batch");
-                    interval.tick().await;
-                    continue;
-                }
-            };
+            .await?;
 
             tracing::info!(jobs = ?jobs.iter().map(|job| job.id).collect::<Vec<_>>(), "Spawning jobs");
 

--- a/rfd-processor/src/scanner.rs
+++ b/rfd-processor/src/scanner.rs
@@ -5,6 +5,7 @@
 use rfd_github::{GitHubError, GitHubRfdUpdate};
 use rfd_model::{storage::JobStore, NewJob};
 use std::sync::Arc;
+use tap::TapFallible;
 use thiserror::Error;
 use tokio::time::interval;
 use v_model::storage::StoreError;
@@ -25,35 +26,29 @@ pub async fn scanner(ctx: Arc<Context>) -> Result<(), ScannerError> {
 
     loop {
         if ctx.scanner.enabled {
-            // Errors reaching GitHub (including transient auth and rate limit failures) must not
-            // take down the scanner. Skip this scan and try again on the next tick
-            match ctx
+            let updates = ctx
                 .github
                 .repository
                 .get_rfd_sync_updates(&ctx.github.client)
                 .await
-            {
-                Ok(updates) => {
-                    for update in updates {
-                        match JobStore::upsert(&ctx.db.storage, update.clone().into_job()).await {
-                            Ok(job) => tracing::trace!(?job.id, "Added job to the queue"),
-                            Err(err) => {
-                                match err {
-                                    StoreError::Conflict => {
-                                        // Nothing to do here, we expect uniqueness conflicts. It is expected
-                                        // that the scanner picks ups redundant jobs for RFDs that have not
-                                        // changed since the last scan
-                                    }
-                                    err => {
-                                        tracing::warn!(?err, ?update, "Failed to add job")
-                                    }
-                                }
+                .tap_err(|err| tracing::error!(?err, "Failed to fetch RFD updates from GitHub"))
+                .unwrap_or_default();
+
+            for update in updates {
+                match JobStore::upsert(&ctx.db.storage, update.clone().into_job()).await {
+                    Ok(job) => tracing::trace!(?job.id, "Added job to the queue"),
+                    Err(err) => {
+                        match err {
+                            StoreError::Conflict => {
+                                // Nothing to do here, we expect uniqueness conflicts. It is expected
+                                // that the scanner picks ups redundant jobs for RFDs that have not
+                                // changed since the last scan
+                            }
+                            err => {
+                                tracing::warn!(?err, ?update, "Failed to add job")
                             }
                         }
                     }
-                }
-                Err(err) => {
-                    tracing::error!(?err, "Failed to fetch RFD updates from GitHub");
                 }
             }
         }

--- a/rfd-processor/src/scanner.rs
+++ b/rfd-processor/src/scanner.rs
@@ -25,27 +25,35 @@ pub async fn scanner(ctx: Arc<Context>) -> Result<(), ScannerError> {
 
     loop {
         if ctx.scanner.enabled {
-            let updates = ctx
+            // Errors reaching GitHub (including transient auth and rate limit failures) must not
+            // take down the scanner. Skip this scan and try again on the next tick
+            match ctx
                 .github
                 .repository
                 .get_rfd_sync_updates(&ctx.github.client)
-                .await?;
-
-            for update in updates {
-                match JobStore::upsert(&ctx.db.storage, update.clone().into_job()).await {
-                    Ok(job) => tracing::trace!(?job.id, "Added job to the queue"),
-                    Err(err) => {
-                        match err {
-                            StoreError::Conflict => {
-                                // Nothing to do here, we expect uniqueness conflicts. It is expected
-                                // that the scanner picks ups redundant jobs for RFDs that have not
-                                // changed since the last scan
-                            }
-                            err => {
-                                tracing::warn!(?err, ?update, "Failed to add job")
+                .await
+            {
+                Ok(updates) => {
+                    for update in updates {
+                        match JobStore::upsert(&ctx.db.storage, update.clone().into_job()).await {
+                            Ok(job) => tracing::trace!(?job.id, "Added job to the queue"),
+                            Err(err) => {
+                                match err {
+                                    StoreError::Conflict => {
+                                        // Nothing to do here, we expect uniqueness conflicts. It is expected
+                                        // that the scanner picks ups redundant jobs for RFDs that have not
+                                        // changed since the last scan
+                                    }
+                                    err => {
+                                        tracing::warn!(?err, ?update, "Failed to add job")
+                                    }
+                                }
                             }
                         }
                     }
+                }
+                Err(err) => {
+                    tracing::error!(?err, "Failed to fetch RFD updates from GitHub");
                 }
             }
         }


### PR DESCRIPTION
rfd-processor has recently crashed multiple times due to `401 Bad credentials` from GitHub. This error was not caught and exits the process.

```
Error: Scanner(GitHub(ClientError(HttpError { status: 401, ... "Bad credentials" ... })))
```
Perhaps caused by an expired App installation token (1hr expiration I think).

This was compounded the systemd service missing a `Restart=always` -- so a stray github error would cause rfd-processor to die.