### PR TITLE
Bump v-api to v0.4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,8 +964,8 @@ dependencies = [
 
 [[package]]
 name = "dropshot-authorization-header"
-version = "0.4.9"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
+version = "0.4.10"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.10#e012ae208a9e4b5fbefdc8f2807b253441036e26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1157,9 +1157,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1182,15 +1182,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1199,15 +1199,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1216,15 +1216,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1234,9 +1234,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4956,8 +4956,8 @@ dependencies = [
 
 [[package]]
 name = "v-api"
-version = "0.4.9"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
+version = "0.4.10"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.10#e012ae208a9e4b5fbefdc8f2807b253441036e26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5001,8 +5001,8 @@ dependencies = [
 
 [[package]]
 name = "v-api-param"
-version = "0.4.9"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
+version = "0.4.10"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.10#e012ae208a9e4b5fbefdc8f2807b253441036e26"
 dependencies = [
  "secrecy",
  "serde",
@@ -5011,8 +5011,8 @@ dependencies = [
 
 [[package]]
 name = "v-api-permission-derive"
-version = "0.4.9"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
+version = "0.4.10"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.10#e012ae208a9e4b5fbefdc8f2807b253441036e26"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5022,8 +5022,8 @@ dependencies = [
 
 [[package]]
 name = "v-cli-sdk"
-version = "0.4.9"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
+version = "0.4.10"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.10#e012ae208a9e4b5fbefdc8f2807b253441036e26"
 dependencies = [
  "anyhow",
  "clap",
@@ -5045,8 +5045,8 @@ dependencies = [
 
 [[package]]
 name = "v-model"
-version = "0.4.9"
-source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.9#966c2464a327864058d530a2806ac55ab0a84384"
+version = "0.4.10"
+source = "git+https://github.com/oxidecomputer/v-api?tag=v0.4.10#e012ae208a9e4b5fbefdc8f2807b253441036e26"
 dependencies = [
  "async-bb8-diesel",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ diesel_migrations = { version = "2.3.2" }
 dirs = "6.0.0"
 dropshot = "0.17"
 dropshot-verified-body = { git = "https://github.com/oxidecomputer/dropshot-verified-body", rev = "0b124eeb0f52db783a44d395a41425a1f9b709b7" }
-futures = "0.3.32"
+futures = "0.3.33"
 google-drive3 = { version = "7.0.0", default-features = false, features = ["yup-oauth2-service-account", "aws-lc-rs"] }
 google-storage1 = "7.0.0"
 hex = "0.4.3"
@@ -76,10 +76,10 @@ tracing-appender = "0.2.5"
 tracing-slog = { git = "https://github.com/oxidecomputer/tracing-slog", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
-v-api = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9", default-features = false }
-v-cli-sdk = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9" }
-v-model = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9" }
-v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.9" }
+v-api = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.10", default-features = false }
+v-cli-sdk = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.10" }
+v-model = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.10" }
+v-api-permission-derive = { git = "https://github.com/oxidecomputer/v-api", tag = "v0.4.10" }
 yup-oauth2 = { version = "12.1.2", default-features = false, features = ["hyper-rustls", "service-account", "aws-lc-rs"] }
 
 # Config for 'cargo dist'


### PR DESCRIPTION
- Closes: https://github.com/oxidecomputer/rfd-api/issues/500