### PR TITLE
Fix RFD revision selection and reuse

### DIFF
--- a/rfd-model/src/storage/postgres.rs
+++ b/rfd-model/src/storage/postgres.rs
@@ -142,7 +142,11 @@ impl RfdStore for PostgresStore {
         query = query
             .offset(pagination.offset)
             .limit(pagination.limit)
-            .order((rfd::id.asc(), rfd_revision::committed_at.desc()));
+            .order((
+                rfd::id.asc(),
+                rfd_revision::committed_at.desc(),
+                rfd_revision::created_at.desc(),
+            ));
 
         tracing::trace!(query = ?debug_query(&query), "List RFDs query");
 
@@ -380,7 +384,9 @@ impl RfdMetaStore for PostgresStore {
                 SELECT rfd_revision.id
                 FROM rfd_revision
                 WHERE rfd_revision.rfd_id = rfd.id AND rfd_revision.major_change = TRUE
-                ORDER BY rfd_revision.committed_at DESC
+                ORDER BY
+                    rfd_revision.committed_at DESC,
+                    rfd_revision.created_at DESC
                 LIMIT 1
             )
         WHERE {} AND
@@ -388,12 +394,15 @@ impl RfdMetaStore for PostgresStore {
                 SELECT rfd_revision.id
                 FROM rfd_revision
                 WHERE rfd_revision.rfd_id = rfd.id
-                ORDER BY rfd_revision.committed_at DESC
+                ORDER BY
+                    rfd_revision.committed_at DESC,
+                    rfd_revision.created_at DESC
                 LIMIT 1
             )
         ORDER BY
             rfd_revision.rfd_id ASC,
-            rfd_revision.committed_at DESC
+            rfd_revision.committed_at DESC,
+            rfd_revision.created_at DESC
         LIMIT ${} OFFSET ${}"#,
             where_clause,
             bind_count,
@@ -623,7 +632,9 @@ impl RfdPdfsStore for PostgresStore {
                 SELECT rfd_revision.id
                 FROM rfd_revision
                 WHERE rfd_revision.rfd_id = rfd.id AND rfd_revision.major_change = TRUE
-                ORDER BY rfd_revision.committed_at DESC
+                ORDER BY
+                    rfd_revision.committed_at DESC,
+                    rfd_revision.created_at DESC
                 LIMIT 1
             )
         WHERE {} AND
@@ -631,12 +642,15 @@ impl RfdPdfsStore for PostgresStore {
                 SELECT rfd_revision.id
                 FROM rfd_revision
                 WHERE rfd_revision.rfd_id = rfd.id
-                ORDER BY rfd_revision.committed_at DESC
+                ORDER BY
+                    rfd_revision.committed_at DESC,
+                    rfd_revision.created_at DESC
                 LIMIT 1
             )
         ORDER BY
             rfd_revision.rfd_id ASC,
-            rfd_revision.committed_at DESC
+            rfd_revision.committed_at DESC,
+            rfd_revision.created_at DESC
         LIMIT ${} OFFSET ${}"#,
             where_clause,
             bind_count,
@@ -804,7 +818,10 @@ impl RfdRevisionStore for PostgresStore {
         let query = query
             .offset(pagination.offset)
             .limit(pagination.limit)
-            .order(rfd_revision::committed_at.desc());
+            .order((
+                rfd_revision::committed_at.desc(),
+                rfd_revision::created_at.desc(),
+            ));
 
         tracing::info!(query = ?debug_query(&query), "Run list rfds");
 
@@ -971,7 +988,10 @@ impl RfdRevisionMetaStore for PostgresStore {
         let query = query
             .offset(pagination.offset)
             .limit(pagination.limit)
-            .order(rfd_revision::committed_at.desc());
+            .order((
+                rfd_revision::committed_at.desc(),
+                rfd_revision::created_at.desc(),
+            ));
 
         tracing::info!(query = ?debug_query(&query), "Run list rfd metadata");
 
@@ -1093,7 +1113,10 @@ impl RfdRevisionPdfStore for PostgresStore {
         let query = query
             .offset(pagination.offset)
             .limit(pagination.limit)
-            .order(rfd_revision::committed_at.desc());
+            .order((
+                rfd_revision::committed_at.desc(),
+                rfd_revision::created_at.desc(),
+            ));
 
         tracing::info!(query = ?debug_query(&query), "Run list rfd pdf");
 

--- a/rfd-processor/src/rfd.rs
+++ b/rfd-processor/src/rfd.rs
@@ -358,56 +358,58 @@ impl RemoteRfd {
         )
         .await?;
 
-        let id = RfdRevisionStore::list(
+        let latest_revision = RfdRevisionStore::list(
             storage,
-            vec![RfdRevisionFilter::default()
-                .rfd(Some(vec![rfd.id]))
-                .commit(Some(vec![payload.commit_sha.clone()]))],
+            vec![RfdRevisionFilter::default().rfd(Some(vec![rfd.id]))],
             &ListPagination::latest(),
         )
         .await?
         .into_iter()
-        .next()
-        .map(|revision| {
-            tracing::info!("Found existing RFD revision for this commit. Updating the revision.");
-            revision.id
-        })
-        .unwrap_or_else(|| {
-            tracing::info!("No existing revisions exist for this commit. Creating a new revision.");
-            TypedUuid::new_v4()
-        });
+        .next();
 
-        let revision = RfdRevisionStore::upsert(
-            storage,
-            NewRfdRevision {
-                id,
-                rfd_id: rfd.id,
-                title: payload.title,
-                state: if payload.state.is_empty() {
-                    None
-                } else {
-                    Some(payload.state)
-                },
-                discussion: payload.discussion,
-                authors: if payload.authors.is_empty() {
-                    None
-                } else {
-                    Some(payload.authors)
-                },
-                labels: if payload.labels.is_empty() {
-                    None
-                } else {
-                    Some(payload.labels)
-                },
-                content: payload.content.raw().to_string(),
-                content_format: payload.content_format,
-                sha: payload.sha,
-                commit: payload.commit_sha,
-                committed_at: payload.commit_date,
-                major_change,
-            },
-        )
-        .await?;
+        let revision = match latest_revision {
+            Some(revision) if revision.sha == payload.sha => {
+                tracing::info!(
+                    revision = %revision.id,
+                    "RFD source is unchanged. Using the existing revision."
+                );
+                revision
+            }
+            _ => {
+                tracing::info!("RFD source has changed. Creating a new revision.");
+                RfdRevisionStore::upsert(
+                    storage,
+                    NewRfdRevision {
+                        id: TypedUuid::new_v4(),
+                        rfd_id: rfd.id,
+                        title: payload.title,
+                        state: if payload.state.is_empty() {
+                            None
+                        } else {
+                            Some(payload.state)
+                        },
+                        discussion: payload.discussion,
+                        authors: if payload.authors.is_empty() {
+                            None
+                        } else {
+                            Some(payload.authors)
+                        },
+                        labels: if payload.labels.is_empty() {
+                            None
+                        } else {
+                            Some(payload.labels)
+                        },
+                        content: payload.content.raw().to_string(),
+                        content_format: payload.content_format,
+                        sha: payload.sha,
+                        commit: payload.commit_sha,
+                        committed_at: payload.commit_date,
+                        major_change,
+                    },
+                )
+                .await?
+            }
+        };
 
         let mut existing_pdf = RfdPdfStore::list(
             storage,


### PR DESCRIPTION
Unchanged RFDs can accumulate duplicate revisions with the same commit timestamp.
Latest-revision queries could then select an arbitrary row without a PDF (`/pdf` 404)

- rfd-api: Use `created_at` to deterministically resolve tied commit timestamps.
- rfd-processor:
  - Reuses the existing revision without updating it when the RFD blob is unchanged.
  - Creates a new revision only when the RFD blob changes.
- See: [Some RFDs missing PDFs](https://github.com/oxidecomputer/infra/issues/72)

Existing duplicate rows are left intact.
RFDs whose actual latest revision has no PDF still require reprocessing.

This will fix 199 RFDs that could've non-deterministically returned 404s.
We will need to manually retrigger 34 jobs which currently have no PDF.