### PR TITLE
remix-auth-rfd: Bump to v0.1.6

### DIFF
--- a/remix-auth-rfd/package-lock.json
+++ b/remix-auth-rfd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/remix-auth-rfd",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/remix-auth-rfd",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@oxide/rfd.ts": "^0.15.0",
@@ -588,13 +588,15 @@
       "license": "MIT"
     },
     "node_modules/@oxide/rfd.ts": {
-      "version": "0.15.4",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@oxide/rfd.ts/-/rfd.ts-0.15.5.tgz",
+      "integrity": "sha512-Vonl3ATrCauIDpl9b0Mp47GwLXhnHkQ+/OD3ke1m0B2bwiP/fmRFyX1rMm8U8VPEWIDa2Mo58yRMJknh8p+oJg==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.23.8 || ^4.0.0"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2073,9 +2075,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/remix-auth-rfd/package.json
+++ b/remix-auth-rfd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/remix-auth-rfd",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
Includes:
- https://github.com/oxidecomputer/rfd-api/pull/505
- https://github.com/oxidecomputer/rfd-api/pull/401

Notably, this bumps react-router from ^7.4.0 to ^8.3.0, typescript from ^5.7.2 to ^6.0.3 and makes node24 the minimum supported version.