### PR TITLE
Bump regex crate to v1.13.1. Switch to regex macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ octorust = { git = "https://github.com/oxidecomputer/third-party-api-clients", t
 partial-struct = { git = "https://github.com/oxidecomputer/partial-struct" }
 progenitor = { version = "0.14" }
 progenitor-client = { version = "0.14" }
-regex = "1.12.3"
+regex = "1.13.1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }
 reqwest-middleware = "0.5"
 reqwest-retry = "0.9"

--- a/rfd-api/src/endpoints/webhook.rs
+++ b/rfd-api/src/endpoints/webhook.rs
@@ -11,7 +11,7 @@ use dropshot::{
 use dropshot_verified_body::{hmac::HmacVerifiedBody, services::github::GitHubWebhookVerification};
 use http::HeaderName;
 use newtype_uuid::{GenericUuid, TypedUuid};
-use regex::Regex;
+use regex::regex;
 use rfd_model::{NewJob, WebhookDeliveryId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -94,7 +94,7 @@ impl GitHubCommitPayload {
         // commit, changes will be accepted to rejected. Changes on the default repository branch
         // are accepted for all RFDs, but on a RFD specific branch (i.e. 0123) on changes to
         // RFD 123 are accepted. Changes on non-default, non-rfd branches are always rejected
-        let pattern = Regex::new(r#"^rfd/(\d{4})/"#).unwrap();
+        let pattern = regex!(r#"^rfd/(\d{4})/"#);
         let branch = self.branch();
 
         self.changed_files()

--- a/rfd-data/src/content/asciidoc.rs
+++ b/rfd-data/src/content/asciidoc.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use regex::Regex;
+use regex::{regex, Regex};
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -123,10 +123,10 @@ impl<'a> RfdAsciidoc<'a> {
         title.map(|m| m.as_str())
     }
 
-    fn title_pattern() -> Regex {
+    fn title_pattern() -> &'static Regex {
         // This pattern also include markdown title handling fallbacks to handle malformed
         // documents
-        Regex::new(r"(?m)^[=#][ ]+(?:RFD ?)?(?:\d+:? )?(.*)\n").unwrap()
+        regex!(r"(?m)^[=#][ ]+(?:RFD ?)?(?:\d+:? )?(.*)\n")
     }
 
     fn author_line(content: &str) -> Option<&str> {
@@ -150,8 +150,8 @@ impl<'a> RfdAsciidoc<'a> {
         Self::title_pattern().splitn(content, 2).nth(1)
     }
 
-    fn include_pattern() -> Regex {
-        Regex::new(r"(?m)^include::(.*)\[\]$").unwrap()
+    fn include_pattern() -> &'static Regex {
+        regex!(r"(?m)^include::(.*)\[\]$")
     }
 
     pub fn includes(&'a self) -> Vec<AsciidocInclude<'a>> {
@@ -189,7 +189,7 @@ impl<'a> RfdDocument for RfdAsciidoc<'a> {
     type Error = RfdAsciidocError;
 
     fn get_title(&self) -> Option<&str> {
-        let fallback_title_pattern = Regex::new(r"(?m)^= (.*)$").unwrap();
+        let fallback_title_pattern = regex!(r"(?m)^= (.*)$");
 
         if let Some(caps) = Self::title_pattern().captures(&self.content) {
             Some(caps.get(1).unwrap().as_str().trim())

--- a/rfd-data/src/content/markdown.rs
+++ b/rfd-data/src/content/markdown.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use regex::Regex;
+use regex::{regex, Regex};
 use std::borrow::Cow;
 
 use super::RfdDocument;
@@ -61,8 +61,8 @@ impl<'a> RfdMarkdown<'a> {
         Regex::new(&format!(r"(?m)^{}:(.*)$\n", attr)).unwrap()
     }
 
-    fn title_pattern(&self) -> Regex {
-        Regex::new(r"(?m)^[#].*$[\n\r]+").unwrap()
+    fn title_pattern(&self) -> &'static Regex {
+        regex!(r"(?m)^[#].*$[\n\r]+")
     }
 }
 
@@ -70,8 +70,8 @@ impl<'a> RfdDocument for RfdMarkdown<'a> {
     type Error = ();
 
     fn get_title(&self) -> Option<&str> {
-        let title_pattern = Regex::new(r"(?m)^[=# ]+(?:RFD ?)?(?:\d+:? )?(.*)$").unwrap();
-        let fallback_title_pattern = Regex::new(r"(?m)^# (.*)$").unwrap();
+        let title_pattern = regex!(r"(?m)^[=# ]+(?:RFD ?)?(?:\d+:? )?(.*)$");
+        let fallback_title_pattern = regex!(r"(?m)^# (.*)$");
 
         if let Some(caps) = title_pattern.captures(&self.content) {
             Some(caps.get(1).unwrap().as_str().trim())

--- a/rfd-github/src/lib.rs
+++ b/rfd-github/src/lib.rs
@@ -21,7 +21,7 @@ use octorust::{
     types::{GitCreateRefRequest, PullRequestSimple, ReposCreateUpdateFileContentsRequest},
     Client, ClientError, Response,
 };
-use regex::Regex;
+use regex::regex;
 use rfd_data::{
     content::{RfdAsciidoc, RfdAsciidocError, RfdContent, RfdMarkdown},
     RfdNumber,
@@ -162,7 +162,7 @@ impl GitHubRfdRepo {
     }
 
     pub async fn branches(&self) -> Result<Vec<GitHubRfdLocation>, GitHubError> {
-        let branch_pattern = Regex::new(r#"^\d{4}$"#).unwrap();
+        let branch_pattern = regex!(r#"^\d{4}$"#);
         let responses = self
             .client
             .repos()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -322,9 +322,9 @@ fn format_code(code: String) -> String {
 
     // Add newlines after end-braces at <= two levels of indentation. Rustfmt's
     // `blank_lines_lower_bound` is broken.
-    let regex = regex::Regex::new(r#"(})(\n\s{0,8}[^} ])"#).unwrap();
+    let regex = regex::regex!(r#"(})(\n\s{0,8}[^} ])"#);
     let contents = regex.replace_all(&contents, "$1\n$2");
 
-    let regex = regex::Regex::new(r#"(\n\s*///)(\S)"#).unwrap();
+    let regex = regex::regex!(r#"(\n\s*///)(\S)"#);
     regex.replace_all(&contents, "$1 $2").to_string()
 }


### PR DESCRIPTION
- Bump regex crate from v1.12.3
- Switch to new fancy `regex::regex!` macros (compile once and re-use)
- Add regex cache for attribute lookups 

Unimproved: `RfdAsciidoc::attr_pattern` and `RfdMarkdown::attr_pattern` create regexes per-call (yuk!).